### PR TITLE
CNDIT-229 - Save FHIR Document to Database

### DIFF
--- a/report-service/sql-script/elr_fhir.sql
+++ b/report-service/sql-script/elr_fhir.sql
@@ -1,0 +1,9 @@
+CREATE TABLE [NBS_DataIngest].[dbo].[elr_fhir] (
+    id UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
+    fhir_message NVARCHAR(MAX) not null,
+    raw_message_id UNIQUEIDENTIFIER FOREIGN KEY REFERENCES [NBS_DataIngest].[dbo].[elr_raw](id),
+    created_by NVARCHAR(255) NOT NULL,
+    updated_by NVARCHAR(255) NOT NULL,
+    created_on DATETIME NOT NULL DEFAULT getdate(),
+    updated_on DATETIME NULL
+)

--- a/report-service/sql-script/elr_validated.sql
+++ b/report-service/sql-script/elr_validated.sql
@@ -1,6 +1,6 @@
 CREATE TABLE [NBS_DataIngest].[dbo].[elr_validated] (
     id UNIQUEIDENTIFIER PRIMARY KEY default NEWID(),
-    raw_id UNIQUEIDENTIFIER not null,
+    raw_id UNIQUEIDENTIFIER FOREIGN KEY REFERENCES [NBS_DataIngest].[dbo].[elr_raw](id),
     message_type nvarchar(255) not null,
     message_version nvarchar(255),
     validated_message ntext not null,

--- a/report-service/sql-script/elr_validated.sql
+++ b/report-service/sql-script/elr_validated.sql
@@ -1,6 +1,6 @@
 CREATE TABLE [NBS_DataIngest].[dbo].[elr_validated] (
     id UNIQUEIDENTIFIER PRIMARY KEY default NEWID(),
-    raw_id UNIQUEIDENTIFIER FOREIGN KEY REFERENCES [NBS_DataIngest].[dbo].[elr_raw](id),
+    raw_message_id UNIQUEIDENTIFIER FOREIGN KEY REFERENCES [NBS_DataIngest].[dbo].[elr_raw](id),
     message_type nvarchar(255) not null,
     message_version nvarchar(255),
     validated_message ntext not null,

--- a/report-service/src/main/java/gov/cdc/dataingestion/conversion/integration/HL7ToFHIRConversion.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/conversion/integration/HL7ToFHIRConversion.java
@@ -17,6 +17,7 @@ public class HL7ToFHIRConversion implements IHL7ToFHIRConversion {
         model.setRawId(validatedELRModel.getRawId());
         model.setFhirMessage(output);
         model.setCreatedBy(topicName);
+        model.setUpdatedBy(topicName);
         return model;
     }
 }

--- a/report-service/src/main/java/gov/cdc/dataingestion/conversion/integration/HL7ToFHIRConversion.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/conversion/integration/HL7ToFHIRConversion.java
@@ -1,7 +1,7 @@
 package gov.cdc.dataingestion.conversion.integration;
 
 import gov.cdc.dataingestion.conversion.integration.interfaces.IHL7ToFHIRConversion;
-import gov.cdc.dataingestion.conversion.repository.model.HL7toFhirModel;
+import gov.cdc.dataingestion.conversion.repository.model.HL7ToFHIRModel;
 import gov.cdc.dataingestion.validation.repository.model.ValidatedELRModel;
 import io.github.linuxforhealth.hl7.HL7ToFHIRConverter;
 
@@ -11,8 +11,8 @@ public class HL7ToFHIRConversion implements IHL7ToFHIRConversion {
         this.converter = converter;
     }
 
-    public HL7toFhirModel ConvertHL7v2ToFhir(ValidatedELRModel validatedELRModel, String topicName) throws UnsupportedOperationException {
-        HL7toFhirModel model = new HL7toFhirModel();
+    public HL7ToFHIRModel ConvertHL7v2ToFhir(ValidatedELRModel validatedELRModel, String topicName) throws UnsupportedOperationException {
+        HL7ToFHIRModel model = new HL7ToFHIRModel();
         String output = this.converter.convert(validatedELRModel.getRawMessage());
         model.setRawId(validatedELRModel.getRawId());
         model.setFhirMessage(output);

--- a/report-service/src/main/java/gov/cdc/dataingestion/conversion/integration/interfaces/IHL7ToFHIRConversion.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/conversion/integration/interfaces/IHL7ToFHIRConversion.java
@@ -1,8 +1,8 @@
 package gov.cdc.dataingestion.conversion.integration.interfaces;
 
-import gov.cdc.dataingestion.conversion.repository.model.HL7toFhirModel;
+import gov.cdc.dataingestion.conversion.repository.model.HL7ToFHIRModel;
 import gov.cdc.dataingestion.validation.repository.model.ValidatedELRModel;
 
 public interface IHL7ToFHIRConversion {
-    HL7toFhirModel ConvertHL7v2ToFhir(ValidatedELRModel validatedModel, String topicName);
+    HL7ToFHIRModel ConvertHL7v2ToFhir(ValidatedELRModel validatedModel, String topicName);
 }

--- a/report-service/src/main/java/gov/cdc/dataingestion/conversion/repository/IHL7ToFHIRRepository.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/conversion/repository/IHL7ToFHIRRepository.java
@@ -1,0 +1,9 @@
+package gov.cdc.dataingestion.conversion.repository;
+
+import gov.cdc.dataingestion.conversion.repository.model.HL7ToFHIRModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IHL7ToFHIRRepository extends JpaRepository<HL7ToFHIRModel, String> {
+}

--- a/report-service/src/main/java/gov/cdc/dataingestion/conversion/repository/model/HL7ToFHIRModel.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/conversion/repository/model/HL7ToFHIRModel.java
@@ -7,17 +7,19 @@ import java.sql.Timestamp;
 
 @Entity
 @Table(name = "elr_fhir")
-public class HL7toFhirModel {
+public class HL7ToFHIRModel {
     @Id
     @GenericGenerator(name = "generator", strategy = "guid", parameters = {})
     @GeneratedValue(generator = "generator")
     @Column(name = "id" , columnDefinition="uniqueidentifier")
     private String id;
 
-    @Column(name = "raw_id")
-    private String rawId;
-    @Column(name = "fhir_msg")
+    @Column(name = "fhir_message")
     private String fhirMessage;
+
+    @Column(name = "raw_message_id")
+    private String rawId;
+
     @Transient
     @Column(name = "created_on")
     private Timestamp CreatedOn;

--- a/report-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
@@ -117,8 +117,6 @@ public class KafkaConsumerService {
         String messageType = validatedELRModel.getMessageType();
         if (messageType.equalsIgnoreCase(KafkaHeaderValue.MessageType_HL7v2)) {
             HL7ToFHIRModel convertedModel = iHl7ToFHIRConversion.ConvertHL7v2ToFhir(validatedELRModel, convertedToFhirTopic);
-            // We can save off the fhir record to db here
-            // once data is persisted when can get id from db and push it to producer
             iHL7ToFHIRRepository.save(convertedModel);
             kafkaProducerService.sendMessageAfterConvertedToFhirMessage(convertedModel, convertedToFhirTopic);
         } else {

--- a/report-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
@@ -2,10 +2,10 @@ package gov.cdc.dataingestion.kafka.integration.service;
 
 import ca.uhn.hl7v2.HL7Exception;
 import gov.cdc.dataingestion.conversion.integration.interfaces.IHL7ToFHIRConversion;
+import gov.cdc.dataingestion.conversion.repository.IHL7ToFHIRRepository;
+import gov.cdc.dataingestion.conversion.repository.model.HL7ToFHIRModel;
 import gov.cdc.dataingestion.report.repository.IRawELRRepository;
-import gov.cdc.dataingestion.conversion.repository.model.HL7toFhirModel;
 import gov.cdc.dataingestion.report.repository.model.RawERLModel;
-import gov.cdc.dataingestion.validation.integration.validator.interfaces.ICsvValidator;
 import gov.cdc.dataingestion.validation.integration.validator.interfaces.IHL7v2Validator;
 import gov.cdc.dataingestion.validation.repository.model.ValidatedELRModel;
 import gov.cdc.dataingestion.validation.model.constant.KafkaHeaderValue;
@@ -16,7 +16,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.serializer.DeserializationException;
@@ -43,6 +42,7 @@ public class KafkaConsumerService {
     private IRawELRRepository iRawELRRepository;
     private IValidatedELRRepository iValidatedELRRepository;
     private IHL7ToFHIRConversion iHl7ToFHIRConversion;
+    private IHL7ToFHIRRepository iHL7ToFHIRRepository;
 
 
     public KafkaConsumerService(
@@ -50,12 +50,14 @@ public class KafkaConsumerService {
             IRawELRRepository iRawELRRepository,
             KafkaProducerService kafkaProducerService,
             IHL7v2Validator iHl7v2Validator,
-            IHL7ToFHIRConversion ihl7ToFHIRConversion) {
+            IHL7ToFHIRConversion ihl7ToFHIRConversion,
+            IHL7ToFHIRRepository iHL7ToFHIRepository) {
         this.iValidatedELRRepository = iValidatedELRRepository;
         this.iRawELRRepository = iRawELRRepository;
         this.kafkaProducerService = kafkaProducerService;
         this.iHl7v2Validator = iHl7v2Validator;
         this.iHl7ToFHIRConversion = ihl7ToFHIRConversion;
+        this.iHL7ToFHIRRepository = iHL7ToFHIRepository;
     }
 
     @RetryableTopic(
@@ -114,9 +116,10 @@ public class KafkaConsumerService {
         ValidatedELRModel validatedELRModel = validatedElrResponse.get();
         String messageType = validatedELRModel.getMessageType();
         if (messageType.equalsIgnoreCase(KafkaHeaderValue.MessageType_HL7v2)) {
-            HL7toFhirModel convertedModel = iHl7ToFHIRConversion.ConvertHL7v2ToFhir(validatedELRModel, convertedToFhirTopic);
+            HL7ToFHIRModel convertedModel = iHl7ToFHIRConversion.ConvertHL7v2ToFhir(validatedELRModel, convertedToFhirTopic);
             // We can save off the fhir record to db here
             // once data is persisted when can get id from db and push it to producer
+            iHL7ToFHIRRepository.save(convertedModel);
             kafkaProducerService.sendMessageAfterConvertedToFhirMessage(convertedModel, convertedToFhirTopic);
         } else {
             throw new UnsupportedOperationException("Invalid Message");

--- a/report-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaProducerService.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaProducerService.java
@@ -1,7 +1,7 @@
 package gov.cdc.dataingestion.kafka.integration.service;
 
 import com.google.gson.Gson;
-import gov.cdc.dataingestion.conversion.repository.model.HL7toFhirModel;
+import gov.cdc.dataingestion.conversion.repository.model.HL7ToFHIRModel;
 import gov.cdc.dataingestion.validation.repository.model.ValidatedELRModel;
 import gov.cdc.dataingestion.validation.model.constant.KafkaHeaderValue;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -47,7 +47,7 @@ public class KafkaProducerService {
         sendMessage(record);
     }
 
-    public void sendMessageAfterConvertedToFhirMessage(HL7toFhirModel msg, String topic) {
+    public void sendMessageAfterConvertedToFhirMessage(HL7ToFHIRModel msg, String topic) {
         String uniqueID = fhirMessageKeyPrefix + UUID.randomUUID();
         var record = new ProducerRecord<>(topic, uniqueID, msg.getId());
         sendMessage(record);

--- a/report-service/src/main/java/gov/cdc/dataingestion/validation/repository/model/ValidatedELRModel.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/validation/repository/model/ValidatedELRModel.java
@@ -15,7 +15,7 @@ public class ValidatedELRModel {
     @Column(name = "id" , columnDefinition="uniqueidentifier")
     private String id;
 
-    @Column(name = "raw_id")
+    @Column(name = "raw_message_id")
     private String rawId;
 
     @Column(name = "validated_message")


### PR DESCRIPTION
### Notes
This story is to save the FHIR (converted from HL7) to SQL Server Database. The HL7 record is validated and converted to FHIR document in the previous stories worked by Duc and this is the continuation of that.

Also, created a SQL script to create the required table in the database. Updated the ``elr_validated`` SQL script to reference the raw_id as Foreign Key.

Created a Repository Interface to save the document from the Kafka Consumer Class and updated the model class to reflect the changes made.

### JIRA
https://cdc-nbs.atlassian.net/browse/CNDIT-229

### Testing
I and Duc tested the changes in his local workspace and was able to see the data being saved in the ``elr_fhir`` table in ``NBS_DataIngest`` Database in the AWS RDS Instance.