### PR TITLE
Fix bug where XML pipeline threw parsing exception on specific scenario

### DIFF
--- a/report-service/build.gradle
+++ b/report-service/build.gradle
@@ -93,7 +93,7 @@ task jaxb {
 compileJava.dependsOn jaxb
 
 dependencies {
-	implementation project(':hl7-parser')
+	//implementation project(':hl7-parser')
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 

--- a/report-service/build.gradle
+++ b/report-service/build.gradle
@@ -93,7 +93,7 @@ task jaxb {
 compileJava.dependsOn jaxb
 
 dependencies {
-	//implementation project(':hl7-parser')
+	implementation project(':hl7-parser')
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 

--- a/report-service/src/main/java/gov/cdc/dataingestion/deadletter/model/ElrDeadLetterDto.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/deadletter/model/ElrDeadLetterDto.java
@@ -103,7 +103,7 @@ public class ElrDeadLetterDto {
     }
 
     private String extractGenericExceptionMessage(String message, String originalMessage) {
-        String regexCleanUpSecondLevelForGenericException = "Caused by: java.lang.Exception.(.*+)";
+        String regexCleanUpSecondLevelForGenericException = "Caused by: java.(.*+)";
         var pattern = Pattern.compile(regexCleanUpSecondLevelForGenericException);
         var matcher = pattern.matcher(message);
         if (matcher.find()) {

--- a/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
@@ -2368,6 +2368,18 @@ public class Hl7ToRhapsodysXmlConverter {
         return buildHL7TSType(ts, TS_FMT_ALL);
     }
 
+    private String AppendingTimeStamp(String ts) {
+        if (ts.length() <= 8) {
+            ts = ts + "000000";
+        } else if (ts.length() <= 12) {
+            ts = ts + "00";
+        } else if (ts.length() > 14) {
+            ts = ts.substring(0, 14);
+        }
+        return ts;
+    }
+
+
     private HL7TSType buildHL7TSType(String ts, int outFmt) {
         HL7TSType hl7TSType = new HL7TSType();
 
@@ -2376,14 +2388,12 @@ public class Hl7ToRhapsodysXmlConverter {
         DateTimeFormatter tsFormatter = formatter;
         if (ts.indexOf("-") > 0) {
             tsFormatter = formatterWithZone;
+//            int index = ts.indexOf("-");
+//            String subStr = ts.substring(0, index);
+//            String subStrTimeZone =  ts.substring(index);
+//            ts = AppendingTimeStamp(subStr) + subStrTimeZone;
         } else {
-            if (ts.length() <= 8) {
-                ts = ts + "000000";
-            } else if (ts.length() <= 12) {
-                ts = ts + "00";
-            } else if (ts.length() > 14) {
-                ts = ts.substring(0, 14);
-            }
+            ts = AppendingTimeStamp(ts);
         }
 
         LocalDateTime localDateTime = LocalDateTime.parse(ts, tsFormatter);

--- a/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
@@ -266,7 +266,8 @@ public class Hl7ToRhapsodysXmlConverter {
         for (HL7OrderObservationType ooType : listOfOOTypes) {
             HL7OBRType hl7OBRType = ooType.getObservationRequest();
             if ((null == hl7OBRType.getParent()) && (null == hl7OBRType.getParentResult())) {
-                if ((assumedParentOBRType != hl7OBRType) && (assumedChildOBRType != hl7OBRType) && assumedChildOBRType != null && assumedChildOBRType.getParent() != null) {
+                if ((assumedParentOBRType != hl7OBRType) && (assumedChildOBRType != hl7OBRType) &&
+                        (assumedChildOBRType != null) && (assumedChildOBRType.getParent() != null)) {
                     hl7OBRType.setParent(assumedChildOBRType.getParent());
                     hl7OBRType.setParentResult(assumedChildOBRType.getParentResult());
                 }

--- a/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
@@ -2388,6 +2388,10 @@ public class Hl7ToRhapsodysXmlConverter {
         DateTimeFormatter tsFormatter = formatter;
         if (ts.indexOf("-") > 0) {
             tsFormatter = formatterWithZone;
+            int index = ts.indexOf("-");
+            String subStr = ts.substring(0, index);
+            String subStrTimeZone =  ts.substring(index);
+            ts = AppendingTimeStamp(subStr) + subStrTimeZone;
         } else {
             ts = AppendingTimeStamp(ts);
         }

--- a/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
@@ -2388,10 +2388,6 @@ public class Hl7ToRhapsodysXmlConverter {
         DateTimeFormatter tsFormatter = formatter;
         if (ts.indexOf("-") > 0) {
             tsFormatter = formatterWithZone;
-//            int index = ts.indexOf("-");
-//            String subStr = ts.substring(0, index);
-//            String subStrTimeZone =  ts.substring(index);
-//            ts = AppendingTimeStamp(subStr) + subStrTimeZone;
         } else {
             ts = AppendingTimeStamp(ts);
         }

--- a/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
@@ -2368,7 +2368,7 @@ public class Hl7ToRhapsodysXmlConverter {
         return buildHL7TSType(ts, TS_FMT_ALL);
     }
 
-    private String AppendingTimeStamp(String ts) {
+    private String appendingTimeStamp(String ts) {
         if (ts.length() <= 8) {
             ts = ts + "000000";
         } else if (ts.length() <= 12) {
@@ -2391,9 +2391,9 @@ public class Hl7ToRhapsodysXmlConverter {
             int index = ts.indexOf("-");
             String subStr = ts.substring(0, index);
             String subStrTimeZone =  ts.substring(index);
-            ts = AppendingTimeStamp(subStr) + subStrTimeZone;
+            ts = appendingTimeStamp(subStr) + subStrTimeZone;
         } else {
-            ts = AppendingTimeStamp(ts);
+            ts = appendingTimeStamp(ts);
         }
 
         LocalDateTime localDateTime = LocalDateTime.parse(ts, tsFormatter);

--- a/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
@@ -267,8 +267,10 @@ public class Hl7ToRhapsodysXmlConverter {
             HL7OBRType hl7OBRType = ooType.getObservationRequest();
             if ((null == hl7OBRType.getParent()) && (null == hl7OBRType.getParentResult())) {
                 if ((assumedParentOBRType != hl7OBRType) && (assumedChildOBRType != hl7OBRType)) {
-                    hl7OBRType.setParent(assumedChildOBRType.getParent());
-                    hl7OBRType.setParentResult(assumedChildOBRType.getParentResult());
+                    if (assumedChildOBRType != null && assumedChildOBRType.getParent() != null) {
+                        hl7OBRType.setParent(assumedChildOBRType.getParent());
+                        hl7OBRType.setParentResult(assumedChildOBRType.getParentResult());
+                    }
                 }
             }
         }

--- a/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
+++ b/report-service/src/main/java/gov/cdc/dataingestion/nbs/converters/Hl7ToRhapsodysXmlConverter.java
@@ -266,11 +266,9 @@ public class Hl7ToRhapsodysXmlConverter {
         for (HL7OrderObservationType ooType : listOfOOTypes) {
             HL7OBRType hl7OBRType = ooType.getObservationRequest();
             if ((null == hl7OBRType.getParent()) && (null == hl7OBRType.getParentResult())) {
-                if ((assumedParentOBRType != hl7OBRType) && (assumedChildOBRType != hl7OBRType)) {
-                    if (assumedChildOBRType != null && assumedChildOBRType.getParent() != null) {
-                        hl7OBRType.setParent(assumedChildOBRType.getParent());
-                        hl7OBRType.setParentResult(assumedChildOBRType.getParentResult());
-                    }
+                if ((assumedParentOBRType != hl7OBRType) && (assumedChildOBRType != hl7OBRType) && assumedChildOBRType != null && assumedChildOBRType.getParent() != null) {
+                    hl7OBRType.setParent(assumedChildOBRType.getParent());
+                    hl7OBRType.setParentResult(assumedChildOBRType.getParentResult());
                 }
             }
         }

--- a/report-service/src/test/java/gov/cdc/dataingestion/kafka/service/KafkaConsumerServiceTest.java
+++ b/report-service/src/test/java/gov/cdc/dataingestion/kafka/service/KafkaConsumerServiceTest.java
@@ -473,7 +473,7 @@ class KafkaConsumerServiceTest {
             msg = getFormattedExceptionMessage(e);
         }
 
-        String expectedMessage = "TEST message exception";
+        String expectedMessage = "lang.Exception: TEST message exception";
 
         ElrDeadLetterDto model = new ElrDeadLetterDto();
 

--- a/report-service/src/test/java/gov/cdc/dataingestion/nbs/converter/Hl7ToRhapsodysXmlConverterTest.java
+++ b/report-service/src/test/java/gov/cdc/dataingestion/nbs/converter/Hl7ToRhapsodysXmlConverterTest.java
@@ -870,4 +870,40 @@ public class Hl7ToRhapsodysXmlConverterTest {
         Assertions.assertNotNull(result.getBreedCode());
         Assertions.assertEquals(expectedMessage, result.getStrain());
     }
+
+    @Test
+    void appendingTimeStampGreaterThan14() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        var parentClass = new Hl7ToRhapsodysXmlConverter();
+        var payload = "20230615123059-timezone";
+        var expectedMessage = "20230615123059";
+        Method privateMethod = Hl7ToRhapsodysXmlConverter.class.getDeclaredMethod("appendingTimeStamp", String.class);
+        privateMethod.setAccessible(true);
+        var result = (String) privateMethod.invoke(parentClass, payload);
+
+        Assertions.assertEquals(expectedMessage, result);
+    }
+
+    @Test
+    void appendingTimeStampLessT14AndGreaterT8() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        var parentClass = new Hl7ToRhapsodysXmlConverter();
+        var payload = "20230615123";
+        var expectedMessage = "2023061512300";
+        Method privateMethod = Hl7ToRhapsodysXmlConverter.class.getDeclaredMethod("appendingTimeStamp", String.class);
+        privateMethod.setAccessible(true);
+        var result = (String) privateMethod.invoke(parentClass, payload);
+
+        Assertions.assertEquals(expectedMessage, result);
+    }
+
+    @Test
+    void appendingTimeStampWithDateOnly() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        var parentClass = new Hl7ToRhapsodysXmlConverter();
+        var payload = "20230615";
+        var expectedMessage = "20230615000000";
+        Method privateMethod = Hl7ToRhapsodysXmlConverter.class.getDeclaredMethod("appendingTimeStamp", String.class);
+        privateMethod.setAccessible(true);
+        var result = (String) privateMethod.invoke(parentClass, payload);
+
+        Assertions.assertEquals(expectedMessage, result);
+    }
 }

--- a/report-service/src/test/java/gov/cdc/dataingestion/nbs/converter/Hl7ToRhapsodysXmlConverterTest.java
+++ b/report-service/src/test/java/gov/cdc/dataingestion/nbs/converter/Hl7ToRhapsodysXmlConverterTest.java
@@ -25,6 +25,9 @@ import gov.cdc.dataingestion.nbs.jaxb.*;
 import jakarta.xml.bind.JAXBException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -871,11 +874,14 @@ public class Hl7ToRhapsodysXmlConverterTest {
         Assertions.assertEquals(expectedMessage, result.getStrain());
     }
 
-    @Test
-    void appendingTimeStampGreaterThan14() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    @ParameterizedTest
+    @CsvSource({
+            "20230615123059-timezone, 20230615123059",
+            "20230615123, 2023061512300",
+            "20230615, 20230615000000"
+    })
+    void testAppendingTimeStamp(String payload, String expectedMessage) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         var parentClass = new Hl7ToRhapsodysXmlConverter();
-        var payload = "20230615123059-timezone";
-        var expectedMessage = "20230615123059";
         Method privateMethod = Hl7ToRhapsodysXmlConverter.class.getDeclaredMethod("appendingTimeStamp", String.class);
         privateMethod.setAccessible(true);
         var result = (String) privateMethod.invoke(parentClass, payload);
@@ -883,27 +889,4 @@ public class Hl7ToRhapsodysXmlConverterTest {
         Assertions.assertEquals(expectedMessage, result);
     }
 
-    @Test
-    void appendingTimeStampLessT14AndGreaterT8() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        var parentClass = new Hl7ToRhapsodysXmlConverter();
-        var payload = "20230615123";
-        var expectedMessage = "2023061512300";
-        Method privateMethod = Hl7ToRhapsodysXmlConverter.class.getDeclaredMethod("appendingTimeStamp", String.class);
-        privateMethod.setAccessible(true);
-        var result = (String) privateMethod.invoke(parentClass, payload);
-
-        Assertions.assertEquals(expectedMessage, result);
-    }
-
-    @Test
-    void appendingTimeStampWithDateOnly() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        var parentClass = new Hl7ToRhapsodysXmlConverter();
-        var payload = "20230615";
-        var expectedMessage = "20230615000000";
-        Method privateMethod = Hl7ToRhapsodysXmlConverter.class.getDeclaredMethod("appendingTimeStamp", String.class);
-        privateMethod.setAccessible(true);
-        var result = (String) privateMethod.invoke(parentClass, payload);
-
-        Assertions.assertEquals(expectedMessage, result);
-    }
 }


### PR DESCRIPTION
CNDIT-496's issues:
- Xml pipeline failed and threw message into dlt in this scenario
  - Message contain date time with time zone such as "20230101125901-0700". Initially, we didn't handle this properly and it caused the parsing exception
- Second issue in the xml pipeline is a null exception at OBR type. Added null check

Unit test result
![image](https://github.com/CDCgov/NEDSS-DataIngestion/assets/117302958/37545a8b-a8b3-478b-af66-0250abc0b952)
