### PR TITLE
Cndit 666 pometheus port

### DIFF
--- a/.github/workflows/Build-data-ingestion-service.yaml
+++ b/.github/workflows/Build-data-ingestion-service.yaml
@@ -5,7 +5,6 @@ on:
       - main
       - master
       - rel-**
-      - CNDIT-640-github-**
     paths-ignore:
       - "docker-compose.yml"
       - "**.md"

--- a/report-service/src/main/resources/application.yaml
+++ b/report-service/src/main/resources/application.yaml
@@ -1,3 +1,6 @@
+server:
+  port: 8081
+
 management:
   endpoint:
     prometheus:


### PR DESCRIPTION
Update application.yaml -
The foundation team suggested changing the data-ingestion service port from 8080 to 8081, as 8080 conflicted with other services for Prometheus.

Build-data-ingestion-service.yaml - Removed branch name added during CICD pipeline testing.