### PR TITLE
Cndit 853 - fixing error where xml pipeline is being executed in the loop

### DIFF
--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/config/KafkaConsumerConfig.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/config/KafkaConsumerConfig.java
@@ -24,6 +24,8 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers = "";
 
+    // Higher value for more intensive operation, also increase latency
+    // default is 30000, equivalent to 5 min
     @Value("${spring.kafka.consumer.maxPollIntervalMs}")
     private String maxPollInterval = "";
 

--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/exception/DiAsyncException.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/exception/DiAsyncException.java
@@ -1,0 +1,7 @@
+package gov.cdc.dataingestion.exception;
+
+public class DiAsyncException extends RuntimeException  {
+    public DiAsyncException(String message) {
+        super(message);
+    }
+}

--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
@@ -438,8 +438,8 @@ public class KafkaConsumerService {
     }
     private void xmlConversionHandler(String message, String operation) {
 
-        // Update: change method to Async process, intensive process in this method cause consumer lagging and strange behavior
-        // TODO: consider breaking down this logic
+        // Update: changed method to async process, intensive process in this method cause consumer lagging, delay and strange behavior
+        // TODO: considering breaking down this logic (NOTE)
         // PROCESS as follow:
         //  - HL7 -> XML
                 // xml conversion can be broke down into multiple smaller pipeline

--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
@@ -53,6 +53,7 @@ import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static gov.cdc.dataingestion.share.helper.TimeStampHelper.getCurrentTimeStamp;
 
@@ -435,53 +436,74 @@ public class KafkaConsumerService {
             throw new ConversionPrepareException("Validation ELR Record Not Found");
         }
     }
-    private void xmlConversionHandler(String message, String operation) throws XmlConversionException, DiHL7Exception, JAXBException, IOException {
-        log.debug("Received message id will be retrieved from db and associated hl7 will be converted to xml");
+    private void xmlConversionHandler(String message, String operation) {
 
-        String hl7Msg = "";
-        if (operation.equalsIgnoreCase(EnumKafkaOperation.INJECTION.name())) {
-            Optional<ValidatedELRModel> validatedElrResponse = this.iValidatedELRRepository.findById(message);
-            hl7Msg = validatedElrResponse.get().getRawMessage();
-        } else {
-            Optional<ElrDeadLetterModel> response = this.elrDeadLetterRepository.findById(message);
-            if (response.isPresent()) {
-                var validMessage = iHl7v2Validator.messageStringValidation(response.get().getMessage());
-                validMessage = iHl7v2Validator.processFhsMessage(validMessage);
-                hl7Msg = validMessage;
-            } else {
-                throw new XmlConversionException(errorDltMessage);
+        // Update: change method to Async process, intensive process in this method cause consumer lagging and strange behavior
+        // TODO: consider breaking down this logic
+        // PROCESS as follow:
+        //  - HL7 -> XML
+                // xml conversion can be broke down into multiple smaller pipeline
+        //  - Saving record to status table can also be broke to downstream pipeline
+        CompletableFuture.runAsync(() -> {
+            log.debug("Received message id will be retrieved from db and associated hl7 will be converted to xml");
+
+            String hl7Msg = "";
+            try {
+                if (operation.equalsIgnoreCase(EnumKafkaOperation.INJECTION.name())) {
+                    Optional<ValidatedELRModel> validatedElrResponse = this.iValidatedELRRepository.findById(message);
+                    hl7Msg = validatedElrResponse.map(ValidatedELRModel::getRawMessage).orElse("");
+                } else {
+                    Optional<ElrDeadLetterModel> response = this.elrDeadLetterRepository.findById(message);
+                    if (response.isPresent()) {
+                        var validMessage = iHl7v2Validator.messageStringValidation(response.get().getMessage());
+                        validMessage = iHl7v2Validator.processFhsMessage(validMessage);
+                        hl7Msg = validMessage;
+                    } else {
+                        throw new XmlConversionException(errorDltMessage);
+                    }
+                }
+                HL7ParsedMessage<OruR1> parsedMessage = Hl7ToRhapsodysXmlConverter.getInstance().parsedStringToHL7(hl7Msg);
+                String rhapsodyXml = Hl7ToRhapsodysXmlConverter.getInstance().convert(message, parsedMessage);
+
+                // Modified from debug ==> info to capture xml for analysis.
+                // Please leave below at "info" level for the time being, before going live,
+                // this will be changed to debug
+                log.info("rhapsodyXml: {}", rhapsodyXml);
+
+                NbsInterfaceModel nbsInterfaceModel = nbsRepositoryServiceProvider.saveXmlMessage(message, rhapsodyXml, parsedMessage);
+
+
+                // Once the XML is saved to the NBS_Interface table, we get the ID to save it
+                // in the Data Ingestion elr_record_status_id table, so that we can get the status
+                // of the record straight-forward from the NBS_Interface table.
+
+                if(nbsInterfaceModel == null) {
+                    customMetricsBuilder.incrementXmlConversionRequestedFailure();
+                }
+                else {
+                    customMetricsBuilder.incrementXmlConversionRequestedSuccess();
+                    ReportStatusIdData reportStatusIdData = new ReportStatusIdData();
+                    Optional<ValidatedELRModel> validatedELRModel = iValidatedELRRepository.findById(message);
+                    reportStatusIdData.setRawMessageId(validatedELRModel.get().getRawId());
+                    reportStatusIdData.setNbsInterfaceUid(nbsInterfaceModel.getNbsInterfaceUid());
+                    reportStatusIdData.setCreatedBy("SPECIAL_TESTER_1_" + convertedToXmlTopic);
+                    reportStatusIdData.setUpdatedBy(convertedToXmlTopic);
+                    reportStatusIdData.setCreatedOn(getCurrentTimeStamp());
+                    reportStatusIdData.setUpdatedOn(getCurrentTimeStamp());
+                    iReportStatusRepository.save(reportStatusIdData);
+                }
+
+                kafkaProducerService.sendMessageAfterConvertedToXml(rhapsodyXml, convertedToXmlTopic, 0);
+
+            } catch (Exception e) {
+                // Handle any exceptions here
+                throw new DiAsyncException(e.getMessage());
             }
-        }
-        HL7ParsedMessage<OruR1> parsedMessage = Hl7ToRhapsodysXmlConverter.getInstance().parsedStringToHL7(hl7Msg);
-        String rhapsodyXml = Hl7ToRhapsodysXmlConverter.getInstance().convert(message, parsedMessage);
+        });
 
-        // Modified from debug ==> info to capture xml for analysis.
-        // Please leave below at "info" level for the time being, before going live,
-        // this will be changed to debug
-        log.info("rhapsodyXml: {}", rhapsodyXml);
-      
-        NbsInterfaceModel nbsInterfaceModel = nbsRepositoryServiceProvider.saveXmlMessage(message, rhapsodyXml, parsedMessage);
-        kafkaProducerService.sendMessageAfterConvertedToXml(rhapsodyXml, convertedToXmlTopic, 0);
 
-        // Once the XML is saved to the NBS_Interface table, we get the ID to save it
-        // in the Data Ingestion elr_record_status_id table, so that we can get the status
-        // of the record straight-forward from the NBS_Interface table.
 
-        if(nbsInterfaceModel == null) {
-            customMetricsBuilder.incrementXmlConversionRequestedFailure();
-        }
-        else {
-            customMetricsBuilder.incrementXmlConversionRequestedSuccess();
-            ReportStatusIdData reportStatusIdData = new ReportStatusIdData();
-            Optional<ValidatedELRModel> validatedELRModel = iValidatedELRRepository.findById(message);
-            reportStatusIdData.setRawMessageId(validatedELRModel.get().getRawId());
-            reportStatusIdData.setNbsInterfaceUid(nbsInterfaceModel.getNbsInterfaceUid());
-            reportStatusIdData.setCreatedBy(convertedToXmlTopic);
-            reportStatusIdData.setUpdatedBy(convertedToXmlTopic);
-            reportStatusIdData.setCreatedOn(getCurrentTimeStamp());
-            reportStatusIdData.setUpdatedOn(getCurrentTimeStamp());
-            iReportStatusRepository.save(reportStatusIdData);
-        }
+
     }
     private void validationHandler(String message, boolean hl7ValidationActivated) throws DuplicateHL7FileFoundException, DiHL7Exception {
         Optional<RawERLModel> rawElrResponse = this.iRawELRRepository.findById(message);

--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
@@ -439,7 +439,7 @@ public class KafkaConsumerService {
     private void xmlConversionHandler(String message, String operation) {
 
         // Update: changed method to async process, intensive process in this method cause consumer lagging, delay and strange behavior
-        // TODO: considering breaking down this logic (NOTE)
+        // TODO: considering breaking down this logic (NOTE) //NOSONAR
         // PROCESS as follow:
         //  - HL7 -> XML
                 // xml conversion can be broke down into multiple smaller pipeline

--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
@@ -486,7 +486,7 @@ public class KafkaConsumerService {
                     Optional<ValidatedELRModel> validatedELRModel = iValidatedELRRepository.findById(message);
                     reportStatusIdData.setRawMessageId(validatedELRModel.get().getRawId());
                     reportStatusIdData.setNbsInterfaceUid(nbsInterfaceModel.getNbsInterfaceUid());
-                    reportStatusIdData.setCreatedBy("SPECIAL_TESTER_1_" + convertedToXmlTopic);
+                    reportStatusIdData.setCreatedBy(convertedToXmlTopic);
                     reportStatusIdData.setUpdatedBy(convertedToXmlTopic);
                     reportStatusIdData.setCreatedOn(getCurrentTimeStamp());
                     reportStatusIdData.setUpdatedOn(getCurrentTimeStamp());

--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
@@ -49,9 +49,6 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.sql.Timestamp;
-import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -488,8 +485,10 @@ public class KafkaConsumerService {
                     reportStatusIdData.setNbsInterfaceUid(nbsInterfaceModel.getNbsInterfaceUid());
                     reportStatusIdData.setCreatedBy(convertedToXmlTopic);
                     reportStatusIdData.setUpdatedBy(convertedToXmlTopic);
-                    reportStatusIdData.setCreatedOn(getCurrentTimeStamp());
-                    reportStatusIdData.setUpdatedOn(getCurrentTimeStamp());
+
+                    var timestamp = getCurrentTimeStamp();
+                    reportStatusIdData.setCreatedOn(timestamp);
+                    reportStatusIdData.setUpdatedOn(timestamp);
                     iReportStatusRepository.save(reportStatusIdData);
                 }
 

--- a/data-ingestion-service/src/test/java/gov/cdc/dataingestion/kafka/service/KafkaConsumerServiceTest.java
+++ b/data-ingestion-service/src/test/java/gov/cdc/dataingestion/kafka/service/KafkaConsumerServiceTest.java
@@ -180,7 +180,7 @@ class KafkaConsumerServiceTest {
     @Test
     void rawConsumerTest() throws DuplicateHL7FileFoundException, DiHL7Exception {
         // Produce a test message to the topic
-//        initialDataInsertionAndSelection(rawTopic);
+        initialDataInsertionAndSelection(rawTopic);
         String message =  guidForTesting;
         produceMessage(rawTopic, message, EnumKafkaOperation.INJECTION);
 
@@ -343,7 +343,6 @@ class KafkaConsumerServiceTest {
         // Produce a test message to the topic
         //  initialDataInsertionAndSelection(xmlPrepTopic);
 
-
         var guidForTesting = "test";
         String message =  guidForTesting;
         produceMessage(xmlPrepTopic, message, EnumKafkaOperation.REINJECTION);
@@ -363,25 +362,17 @@ class KafkaConsumerServiceTest {
         model.setMessage(testHL7Message);
 
 
-        var future = CompletableFuture.runAsync(() -> {
+         CompletableFuture.runAsync(() -> {
             try {
                 assertThrows(DiAsyncException.class, () ->
-                        kafkaConsumerService.handleMessageForXmlConversionElr(value, xmlPrepTopic, EnumKafkaOperation.REINJECTION.name())
+                        kafkaConsumerService.
+                        handleMessageForXmlConversionElr(value, xmlPrepTopic, EnumKafkaOperation.REINJECTION.
+                                name())
                 );
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
-
         });
-
-        ExecutionException thrownException = assertThrows(ExecutionException.class, () -> {
-            future.get(30, TimeUnit.SECONDS);
-        });
-
-        Assertions.assertNotNull(thrownException);
-
-
-
     }
 
     @Test

--- a/data-ingestion-service/src/test/java/gov/cdc/dataingestion/kafka/service/KafkaConsumerServiceTest.java
+++ b/data-ingestion-service/src/test/java/gov/cdc/dataingestion/kafka/service/KafkaConsumerServiceTest.java
@@ -364,11 +364,7 @@ class KafkaConsumerServiceTest {
 
          CompletableFuture.runAsync(() -> {
             try {
-                assertThrows(DiAsyncException.class, () ->
-                        kafkaConsumerService.
-                        handleMessageForXmlConversionElr(value, xmlPrepTopic, EnumKafkaOperation.REINJECTION.
-                                name())
-                ); //NOSONAR
+                assertThrows(DiAsyncException.class, () -> kafkaConsumerService.handleMessageForXmlConversionElr(value, xmlPrepTopic, EnumKafkaOperation.REINJECTION.name())); //NOSONAR
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/data-ingestion-service/src/test/java/gov/cdc/dataingestion/kafka/service/KafkaConsumerServiceTest.java
+++ b/data-ingestion-service/src/test/java/gov/cdc/dataingestion/kafka/service/KafkaConsumerServiceTest.java
@@ -368,7 +368,7 @@ class KafkaConsumerServiceTest {
                         kafkaConsumerService.
                         handleMessageForXmlConversionElr(value, xmlPrepTopic, EnumKafkaOperation.REINJECTION.
                                 name())
-                );
+                ); //NOSONAR
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/data-ingestion-service/src/test/java/gov/cdc/dataingestion/kafka/service/KafkaConsumerServiceTest.java
+++ b/data-ingestion-service/src/test/java/gov/cdc/dataingestion/kafka/service/KafkaConsumerServiceTest.java
@@ -52,10 +52,6 @@ import java.sql.*;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;

--- a/data-ingestion-service/src/test/load-testing/py_generate_msg.py
+++ b/data-ingestion-service/src/test/load-testing/py_generate_msg.py
@@ -1,0 +1,63 @@
+import os
+from faker import Faker
+
+
+# The HL7 fields that are checked by the deduplication algorithm for patient are as follows:
+#    1. MSH 4.2 (SendingApplication.UniversalID) <- how do you do this?
+#    2. OBR 3.1 (FillerOrderNumber.entity identifier) <- 01D0641691?
+#    3. OBR 4.1 (Universal service ID.Identifier)
+#    4. OBR 4.4 (Universal service ID.Alternate Identifier)
+#    5. OBR 7 (Observation Date/Time) <- 2.3.1
+#    6. SPM 17 (Specimen Collection Date/Time) <- 2.5.1
+#    7. PID.2.1 - Id Number
+#    8. PID.2.5 - Identifier Type Code
+#    9. PID.4.4 - Assigning Authority
+#    10. PID.5.1 - Family Name
+#    11. PID.5.2 - Given Name
+#    12. PID.7 - Date/Time of Birth
+#    13. PID.8 - Administrative Sex
+
+
+def generate_unique_patient_messages(num_messages, output_folder):
+    fake = Faker()
+    os.makedirs(output_folder, exist_ok=True)
+
+    for _ in range(num_messages):
+        id_number = fake.random_int(min=10000, max=99999)
+        patient_id = fake.random_int(min=10000, max=99999)
+        person_number = fake.random_int(min=10000, max=99999)
+        family_name = fake.last_name()
+        given_name = fake.first_name()
+        name1= fake.first_name()
+        name1last= fake.last_name()
+        name2= fake.first_name()
+        name2last =fake.last_name()
+        date_of_birth = fake.date_of_birth(minimum_age=18, maximum_age=90).strftime('%Y%m%d')
+        date = fake.date()
+        administrative_sex = fake.random_element(elements=('M', 'F', 'Other'))
+        ssn = fake.ssn()
+        address = fake.address()
+        state = fake.state()
+        city = fake.city()
+        zipcode = fake.zipcode()
+        assigning_authority = fake.company()
+        assigning_authority_id = fake.random_int(min=10000, max=99999)
+        sending_app_id = fake.random_int(min=10000, max=99999)
+        filler_order_entity_id = fake.random_int(min=0, max=999)
+        apt_no = fake.random_int(min= 100, max= 10000)
+        alternate_identifier = fake.random_int(min= 999, max= 99999)
+        fake_message = (
+            f"MSH|^~\&|LABCORP-CORP^OID^ISO|LABCORP^34D0655059^CLIA|ALDOH^OID^ISO|AL^OID^ISO|200604040100||ORU^R01^ORU_R01|20120509010020114_251.2|D|2.5.1|||NE|NE|USA||||V251_IG_LB_LABRPTPH_R1_INFORM_2010FEB^^2.16.840.1.114222.4.3.2.5.2.5^ISO\r"
+            f"SFT|Mirth Corp.|2.0|Mirth Connect|789654||20110101\r"
+            f"PID|1|{patient_id}^^^^SS|{person_number}^^^Baker-Robbins&94534&CLIA^PN^{family_name}^{given_name}||{family_name}^{given_name}^^^^^^^^^^||{date_of_birth}|{administrative_sex}|||0605 Lin Creek Apt. {apt_no} Davieshaven, RI 70327^^West Rebecca^Vermont^95855||^^^^^{ssn}||^^^^^79335\r"
+            f"ORC|RE||20120601{filler_order_entity_id}^LABCORP^34D0655059^CLIA||||||||||||||||||COOSA VALLEY MEDICAL CENTER|315 WEST HICKORY ST.^SUITE 100^SYLACAUGA^AL^35150^USA^^^RICHLAND|^^^^^256^2495780^123|380 WEST HILL ST.^^SYLACAUGA^AL^35150^USA^^^RICHLAND\r"
+            f"OBR|1||20120601{filler_order_entity_id}^LABCORP^34D0655059^CLIA|699-9^ORGANISM COUNT^LN^080186^CULTURE^L|||200603241655|200603241655||342384^JONES^SUSAN||||||46466^BRENTNALL^GERRY^LEE^SR^DR^MD|^^^^^256^2495780|||||200604040139|||F|||46214^MATHIS^GERRY^LEE^SR^DR^MD~44582^JONES^THOMAS^LEE^III^DR^MD~46111^MARTIN^JERRY^L^JR^DR^MD|||12365-4^TOTALLY CRAZY^I9|22582&JONES&TOM&L&JR&DR&MD|22582&MOORE&THOMAS&E&III&DR&MD|44&JONES&SAM&A&JR&MR&MT|82&JONES&THOMASINA&LEE ANN&II&MS&RA\r"
+            f"OBX|1|CE|11475-1^MICROORGANISM IDENTIFIED^LN^080187^RSLT#1^L|1|L-1F701^HAEMOPHILUS INFLUENZAE^SNM^HAEMIN^HAEMOPHILUS INFLUENZAE^L|MG|NEGATIVE|H|||F||||34D0655059^LABCORP BIRMINGHAM^CLIA||||20060401||||Lab1^L^^^^CLIA&2.16.840.1.114222.4.3.2.5.2.100&ISO^^^^1234|1234 Cornell Park Dr^^Blue Ash^OH^45241|\r"
+        )
+        # Create a separate text file for each message
+        file_name = os.path.join(output_folder, f"{given_name}_{family_name}.txt")
+        with open(file_name, 'w') as text_file:
+            text_file.write(fake_message)
+
+if __name__ == "__main__":
+    generate_unique_patient_messages(100, "/Users/DucNguyen/Downloads/python_code_for_di/data")

--- a/data-ingestion-service/src/test/load-testing/request_di.sh
+++ b/data-ingestion-service/src/test/load-testing/request_di.sh
@@ -1,0 +1,34 @@
+file_directory="/Users/DucNguyen/Downloads/python_code_for_di/data"
+
+post_message_url="http://localhost:8081/api/reports"
+
+username="username"
+password="password"
+header1="msgType: HL7"
+header2="validationActive: false"
+header3="Content-Type: text/plain"
+header4="Content-Length: <calculated when request is sent>"
+header5="Host: <calculated when request is sent>"
+header6="User-Agent: PostmanRuntime/7.36.0"
+header7="Accept: */*"
+header8="Accept-Encoding: gzip, deflate, br"
+header9="Connection: keep-alive"
+header10="Authorization: Basic ZGl0ZWFtYWRtaW46dGVtcDEyMw=="
+header11="Cache-Control: no-cache"
+header12="Postman-Token: <calculated when request is sent>"
+
+# Iterate over each file in the directory
+for filename in "$file_directory"/*.txt; do
+    if [ -f "$filename" ]; then
+        message_content=$(cat "$filename")
+        echo "Sending request for file: $filename"
+        #echo "Content: $message_content"
+        curl -X POST \
+            -H "$header1" \
+            -H "$header2" \
+            -H "$header3" \
+            -u "$username:$password" \
+            -d "$message_content" \
+            "$post_message_url"
+    fi
+done


### PR DESCRIPTION
**Error:** 
  - indefinite loop occurred within xml-transformation logic

**Method info:** 
  - prior to this pr, the method is executed synchronously as follow converting data to xml (intensive process) -> persist data to nbs -> trigger producer -> persist data to di.


**Scenario and issue:** 
  - When making like 1 to 10 requests subsequently, things will work normally. However, when we dump like 100 or 1000 requests, xml transformation logic broke the pipeline and causing the pipeline to be executed in the loop.
  - Due to the synchronous nature and under the heavy load, it seems to cause kafka consumer to be in the strange state such as consumer rebalancing (leading to duplicate processing of msg), consumer lagging (msg taking longer to process)

**Update:**
- Introduced asynchronous process for the xml transformation method
- Added note and guideline for future update and improvement
- Pulled in Snehaa's load testing script into di repos

Test:
- Env: local Di, msk Kafka
- Tested with 100, 200, and 1000 subsequently and DI able to ingested all the message
- Note for high volume ingestion, during 1000 msg ingestion, DI would take around 10 to 15 mins to completed processing all the messages


https://cdc-nbs.atlassian.net/browse/CNDIT-853?atlOrigin=eyJpIjoiYjQxMTFiNWU3NDIxNDBmMDkyNjFmMzA2NGJhMWIxNDciLCJwIjoiaiJ9