### PR TITLE
set validation to true by default, no more header

### DIFF
--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/rawmessage/controller/ElrReportsController.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/rawmessage/controller/ElrReportsController.java
@@ -58,8 +58,8 @@ public class ElrReportsController {
             description = "Submit a plain text HL7 message with msgType header",
             tags = { "dataingestion", "elr" })
     @PostMapping(consumes = MediaType.TEXT_PLAIN_VALUE)
-    public ResponseEntity<String> save(@RequestBody final String payload, @RequestHeader("msgType") String type,  @RequestHeader("validationActive") String validationActive) {
-            if (type.isEmpty() || validationActive.isEmpty()) {
+    public ResponseEntity<String> save(@RequestBody final String payload, @RequestHeader("msgType") String type) {
+            if (type.isEmpty()) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Required headers should not be null");
             }
 
@@ -67,18 +67,13 @@ public class ElrReportsController {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Please provide valid value for msgType header");
             }
 
-            boolean validationCheck = "true".equalsIgnoreCase(validationActive) || "false".equalsIgnoreCase(validationActive);
-            if (!validationCheck) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Please provide valid value for validationActive header: value must be either true or false");
-            }
 
             RawERLDto rawERLDto = new RawERLDto();
             customMetricsBuilder.incrementMessagesProcessed();
             rawERLDto.setType(type);
             rawERLDto.setPayload(payload);
-            if (validationActive.equalsIgnoreCase("true")) {
-                rawERLDto.setValidationActive(true);
-            }
+            rawERLDto.setValidationActive(true);
+
             return ResponseEntity.ok(rawELRService.submission(rawERLDto));
     }
 

--- a/data-ingestion-service/src/test/java/gov/cdc/dataingestion/rawmessage/ElrReportsControllerTest.java
+++ b/data-ingestion-service/src/test/java/gov/cdc/dataingestion/rawmessage/ElrReportsControllerTest.java
@@ -55,7 +55,6 @@ class ElrReportsControllerTest {
         mockMvc.perform(MockMvcRequestBuilders.post("/api/reports")
                         .param("id", "1").with(SecurityMockMvcRequestPostProcessors.jwt())
                         .header("msgType", messageType)
-                        .header("validationActive", "false")
                         .contentType(MediaType.TEXT_PLAIN_VALUE)
                         .content(payload))
                 .andExpect(MockMvcResultMatchers.status().isOk());


### PR DESCRIPTION
Remove HL7 validation header as this is redundant, validator will be on by default for injection and re-injection endpoint