### PR TITLE
Fix for Elr_raw and Elr_dlt showing different timestamps

### DIFF
--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/kafka/integration/service/KafkaConsumerService.java
@@ -401,6 +401,8 @@ public class KafkaConsumerService {
             model.setMessage(elrDeadLetterDto.getMessage());
             model.setCreatedBy(elrDeadLetterDto.getCreatedBy());
             model.setUpdatedBy(elrDeadLetterDto.getUpdatedBy());
+            model.setCreatedOn(getCurrentTimeStamp());
+            model.setUpdatedOn(getCurrentTimeStamp());
             this.elrDeadLetterRepository.save(model);
         } catch (Exception e) {
             Gson gson = new Gson();

--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/share/helper/TimeStampHelper.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/share/helper/TimeStampHelper.java
@@ -2,14 +2,21 @@ package gov.cdc.dataingestion.share.helper;
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 
 public class TimeStampHelper {
     private TimeStampHelper() {
 
     }
     public static Timestamp getCurrentTimeStamp() {
-        // Another Option: Timestamp.from(ZonedDateTime.now().toInstant())
-        return Timestamp.from(Instant.now());
+        // Another Option: Timestamp.from(ZonedDateTime.now().toInstant()) //NOSONAR
+        //return Timestamp.from(Instant.now());//old implementation. //NOSONAR
+        LocalDateTime ldt = LocalDateTime.now();
+        ZonedDateTime zdt = ZonedDateTime.of(ldt, ZoneId.systemDefault());
+        ZonedDateTime gmt = zdt.withZoneSameInstant(ZoneId.of("UTC"));
+        return Timestamp.valueOf(gmt.toLocalDateTime());
     }
     public static Instant getInstantNow() {
         return Instant.now();


### PR DESCRIPTION
Fix for Elr_raw and Elr_dlt showing different timestamps. 
It worked correctly when we posted the record from the cloud, but local time was added in the DB if the record was from the local DI service.