### PR TITLE
To remove record id from the Activity Logs display

### DIFF
--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/camel/routes/ElrProcessStatusComponent.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/camel/routes/ElrProcessStatusComponent.java
@@ -29,6 +29,7 @@ public class ElrProcessStatusComponent {
         this.reportStatusService = reportStatusService;
     }
 
+    @SuppressWarnings({"java:S3776"})
     @Handler
     public String process(String body){
         String status = "";

--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/camel/routes/ElrProcessStatusComponent.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/camel/routes/ElrProcessStatusComponent.java
@@ -45,9 +45,12 @@ public class ElrProcessStatusComponent {
                     activityLogSb.append("Status: Failure ");
                     List<EdxActivityLogStatus> edxActivityLogList= messageStatus.getNbsIngestionInfo();
                     for(EdxActivityLogStatus edxActivityLogStatus:edxActivityLogList){
-                        String activityLog ="\n\nRecord Id: " + edxActivityLogStatus.getRecordId()
-                                + " \nRecordType: " + edxActivityLogStatus.getRecordType() + " \nLog Type: "
-                                + edxActivityLogStatus.getLogType() + " \nLog Comment: " + edxActivityLogStatus.getLogComment()
+                        String logComment=edxActivityLogStatus.getLogComment();
+                        if(logComment!=null && logComment.length()>200){
+                            logComment=logComment.substring(0,200);
+                        }
+                        String activityLog = "\n\nRecordType: " + edxActivityLogStatus.getRecordType() + " \nLog Type: "
+                                + edxActivityLogStatus.getLogType() + " \nLog Comment: " + logComment
                                 + " \nRecord Status Time: " + edxActivityLogStatus.getRecordStatusTime();
                         activityLogSb.append(activityLog);
                     }

--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/reportstatus/model/EdxActivityLogStatus.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/reportstatus/model/EdxActivityLogStatus.java
@@ -8,7 +8,6 @@ import java.sql.Timestamp;
 @Getter
 @Setter
 public class EdxActivityLogStatus {
-    private String recordId;
     private String recordType;
     private String logType;
     private String logComment;

--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/reportstatus/service/ReportStatusService.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/reportstatus/service/ReportStatusService.java
@@ -87,7 +87,6 @@ public class ReportStatusService {
 
     private static EdxActivityLogStatus getEdxActivityLogStatus(EdxActivityLogModelView edxActivityLogModel) {
         EdxActivityLogStatus edxActivityLogStatus=new EdxActivityLogStatus();
-        edxActivityLogStatus.setRecordId(edxActivityLogModel.getRecordId());
         edxActivityLogStatus.setRecordType(edxActivityLogModel.getRecordType());
         edxActivityLogStatus.setLogType(edxActivityLogModel.getLogType());
         edxActivityLogStatus.setLogComment(edxActivityLogModel.getLogComment());

--- a/data-ingestion-service/src/test/java/gov/cdc/dataingestion/camel/routes/ElrProcessStatusComponentTest.java
+++ b/data-ingestion-service/src/test/java/gov/cdc/dataingestion/camel/routes/ElrProcessStatusComponentTest.java
@@ -75,6 +75,26 @@ class ElrProcessStatusComponentTest {
         Assertions.assertTrue(processStatus.contains("Status:"));
     }
     @Test
+    void testProcessForNbsFailureWithLogCommentWithMorethan200(){
+        String body = "HL7file-sftpstatus1.txt:7DAC34BD-B011-469A-BF27-25904370E9E3";
+        String rawId = "7DAC34BD-B011-469A-BF27-25904370E9E3";
+
+        MessageStatus status = new MessageStatus();
+        status.getNbsInfo().setNbsInterfaceStatus("Failure");
+        String logComment= "Test Log Comment123 Test Log Comment123 Test Log Comment123 Test Log Comment234 Test Log Comment345 Test Log Comment456 Test Log Comment567 Test Log Comment678 Test Log Comment678 Test Log Comment78901";
+        EdxActivityLogStatus edxActivityLogStatus=new EdxActivityLogStatus();
+        edxActivityLogStatus.setRecordType("Test Record Type");
+        edxActivityLogStatus.setLogType("Test Log Type");
+        edxActivityLogStatus.setLogComment(logComment);
+        edxActivityLogStatus.setRecordStatusTime(new Timestamp(System.currentTimeMillis()));
+        status.getNbsIngestionInfo().add(edxActivityLogStatus);
+        when(reportStatusServiceMock.getMessageStatus(rawId)).thenReturn(
+                status
+        );
+        String processStatus = elrProcessStatusComponent.process(body);
+        Assertions.assertTrue(processStatus.contains("Status:"));
+    }
+    @Test
     void testProcessForNbsValidationFailed() throws Exception {
         String body = "HL7file-sftpstatus1.txt:7DAC34BD-B011-469A-BF27-25904370E9E3";
         String rawId = "7DAC34BD-B011-469A-BF27-25904370E9E3";

--- a/data-ingestion-service/src/test/java/gov/cdc/dataingestion/camel/routes/ElrProcessStatusComponentTest.java
+++ b/data-ingestion-service/src/test/java/gov/cdc/dataingestion/camel/routes/ElrProcessStatusComponentTest.java
@@ -95,6 +95,25 @@ class ElrProcessStatusComponentTest {
         Assertions.assertTrue(processStatus.contains("Status:"));
     }
     @Test
+    void testProcessForNbsFailureWithLogComment_null(){
+        String body = "HL7file-sftpstatus1.txt:7DAC34BD-B011-469A-BF27-25904370E9E3";
+        String rawId = "7DAC34BD-B011-469A-BF27-25904370E9E3";
+
+        MessageStatus status = new MessageStatus();
+        status.getNbsInfo().setNbsInterfaceStatus("Failure");
+         EdxActivityLogStatus edxActivityLogStatus=new EdxActivityLogStatus();
+        edxActivityLogStatus.setRecordType("Test Record Type");
+        edxActivityLogStatus.setLogType("Test Log Type");
+        edxActivityLogStatus.setLogComment(null);
+        edxActivityLogStatus.setRecordStatusTime(new Timestamp(System.currentTimeMillis()));
+        status.getNbsIngestionInfo().add(edxActivityLogStatus);
+        when(reportStatusServiceMock.getMessageStatus(rawId)).thenReturn(
+                status
+        );
+        String processStatus = elrProcessStatusComponent.process(body);
+        Assertions.assertTrue(processStatus.contains("Status:"));
+    }
+    @Test
     void testProcessForNbsValidationFailed() throws Exception {
         String body = "HL7file-sftpstatus1.txt:7DAC34BD-B011-469A-BF27-25904370E9E3";
         String rawId = "7DAC34BD-B011-469A-BF27-25904370E9E3";

--- a/data-ingestion-service/src/test/java/gov/cdc/dataingestion/camel/routes/ElrProcessStatusComponentTest.java
+++ b/data-ingestion-service/src/test/java/gov/cdc/dataingestion/camel/routes/ElrProcessStatusComponentTest.java
@@ -63,7 +63,6 @@ class ElrProcessStatusComponentTest {
         status.getNbsInfo().setNbsInterfaceStatus("Failure");
 
         EdxActivityLogStatus edxActivityLogStatus=new EdxActivityLogStatus();
-        edxActivityLogStatus.setRecordId("Test Record Id");
         edxActivityLogStatus.setRecordType("Test Record Type");
         edxActivityLogStatus.setLogType("Test Log Type");
         edxActivityLogStatus.setLogComment("Test Log Comment");


### PR DESCRIPTION
Removed 'record id' from the status info endpoint and sftp status.