### PR TITLE
[CNDIT-1735] Removed actuator endpoint from auth whitelist

### DIFF
--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/security/config/SecurityConfig.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/security/config/SecurityConfig.java
@@ -27,9 +27,6 @@ public class SecurityConfig {
             "/swagger-ui.html",
             "/webjars/**",
             "/v3/api-docs/**",
-            "/actuator/**",
-            "/actuator/prometheus",
-            "/actuator/prometheus/**",
             "/swagger-ui/**",
             "/api/auth/token"
     };


### PR DESCRIPTION
### Notes
Removed actuator endpoint from auth whitelist to comply with security scan

### JIRA
- https://cdc-nbs.atlassian.net/browse/CNDIT-1735

### Testing
- Tested this in local postman and browser to make sure authentication and token is required to access the actuator endpoints.