### PR TITLE
Add deduplication folder with database container"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ hl7-parser/.gradle/*
 
 ### env ###
 *.env
+
+.vscode/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/deduplication/db/Dockerfile
+++ b/deduplication/db/Dockerfile
@@ -1,0 +1,24 @@
+FROM mcr.microsoft.com/mssql/server:2022-latest
+
+ARG DATABASE_PASSWORD
+
+ENV ACCEPT_EULA=Y \
+  MSSQL_PID='Developer' \
+  SQLCMDPASSWORD=${DATABASE_PASSWORD} \
+  MSSQL_SA_PASSWORD=${DATABASE_PASSWORD} 
+
+USER root
+
+RUN apt-get update \
+  && apt-get install mssql-tools18 unixodbc-dev -y && apt-get clean 
+
+COPY --chown=mssql ./initialize /var/opt/database/initialize/
+
+USER mssql
+
+# Start the database and execute initialization scripts so the data becomes part of the image
+# This is intended for development only
+RUN /opt/mssql/bin/sqlservr & /var/opt/database/initialize/initialize.sh
+
+
+ENTRYPOINT [ "/opt/mssql/bin/sqlservr" ]

--- a/deduplication/db/initialize/initialize.sh
+++ b/deduplication/db/initialize/initialize.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+BASE="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+
+until /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -Q "select 1" &> /dev/null; do
+    sleep 1s
+done;
+
+echo "*************************************************************************"
+echo "  Initializing NBS databases"
+echo "*************************************************************************"
+
+for sql in $(find "$BASE/restore.d" -iname "*.sql" | sort) ; 
+do
+    echo "Executing: $sql"  
+    /opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -i "$sql"
+
+    echo "Completed: $sql"
+done
+
+echo "*************************************************************************"
+echo "  NBS databases ready"
+echo "*************************************************************************"

--- a/deduplication/db/initialize/restore.d/00-initial.sql
+++ b/deduplication/db/initialize/restore.d/00-initial.sql
@@ -1,0 +1,31 @@
+USE [master];
+GO
+
+CREATE DATABASE deduplication;
+GO
+
+USE [deduplication];
+GO
+
+
+CREATE TABLE data_element_configuration (
+	id int IDENTITY (1,1) PRIMARY KEY,
+	configuration NVARCHAR(MAX) NOT NULL,
+	add_time datetime NOT NULL default(current_timestamp));
+GO
+
+CREATE TABLE match_configuration (
+	id int IDENTITY (1,1) PRIMARY KEY,
+	configuration NVARCHAR(MAX) NOT NULL,
+	add_time datetime NOT NULL default(current_timestamp));
+GO
+
+CREATE TABLE nbs_mpi_mapping (
+    id bigint,
+    person_uid bigint,
+    person_parent_uid bigint,
+    mpi_person uniqueidentifier,
+    mpi_patient uniqueidentifier,
+    status varchar,
+    PRIMARY KEY ([id])
+);

--- a/deduplication/db/initialize/restore.d/README.md
+++ b/deduplication/db/initialize/restore.d/README.md
@@ -1,0 +1,17 @@
+# Want to automatically restore data?
+
+Any `.sql` placed here will be restored during startup of the docker container in lexicographic order using `sqlcmd`.
+
+## Important paths
+
+The path to this directory as mounted by the docker container:
+
+```
+/var/opt/db-restore/restore.d
+```
+
+The path to mssql data within the docker container:
+
+```
+/var/opt/mssql/data
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,19 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
     networks:
       - dataingestion
+  deduplication-db:
+    build: 
+      context: ./deduplication/db
+      args:
+          - DATABASE_PASSWORD=${DEDUPLICATION_DATABASE_PASSWORD}
+    container_name: deduplication-mssql
+    ports:
+      - 1434:1433
+    environment:
+      - ACCEPT_EULA=1
+      - SQLCMDPASSWORD=${DEDUPLICATION_DATABASE_PASSWORD}
+      - MSSQL_SA_PASSWORD=${DEDUPLICATION_DATABASE_PASSWORD}
+
 networks:
   dataingestion:
     name: dataingestion


### PR DESCRIPTION
## Notes

Adds a `deduplication` directory to contain service(s), development database, and other items relevant to patient deduplication.

Database image requires a `DEDUPLICATION_DATABASE_PASSWORD` environment variable be set. It is recommended for developers to create a `.env` file with the desired password.

```bash
DEDUPLICATION_DATABASE_PASSWORD=fake.fake.fake.1234
```

## JIRA

- **Related story**: [CND-146](https://cdc-nbs.atlassian.net/browse/CND-146)

## Checklist

- [x] PR focuses on a single story.
- [x] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [x] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [x] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [x] Is the `gradle build` logs attached?

[CND-146]: https://cdc-nbs.atlassian.net/browse/CND-146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ