### PR TITLE
Fix build 🤞

### DIFF
--- a/cdaschema/build.gradle
+++ b/cdaschema/build.gradle
@@ -44,11 +44,6 @@ task generateXmlBeans(type: JavaExec) {
 
 }
 
-task copyJar(type: Copy) {
-  from 'build/libs/cda-schema.jar'
-  into "${project(':data-ingestion-service').projectDir}/libs/"
-}
-
 compileJava.dependsOn generateXmlBeans
 
 // Disable the default jar task
@@ -63,5 +58,9 @@ artifacts {
     archives cdaSchemaJar
 }
 
+task copyJar(type: Copy) {
+  from "${buildDir}/libs/cda-schema.jar"
+  into "${project(':data-ingestion-service').projectDir}/libs/"
+}
 cdaSchemaJar.mustRunAfter compileJava
-build.finalizedBy copyJar
+generateXmlBeans.finalizedBy(copyJar)

--- a/data-ingestion-service/build.gradle
+++ b/data-ingestion-service/build.gradle
@@ -182,7 +182,7 @@ task jaxb {
 compileJava.dependsOn jaxb
 
 if (project != project.rootProject || project.hasProperty('remoteBuild')) {
-	compileJava.mustRunAfter(":hl7-parser:build")
+	compileJava.mustRunAfter(":hl7-parser:copyJar")
 	compileJava.mustRunAfter(":cdaschema:copyJar")
 }
 
@@ -283,7 +283,7 @@ jar {
 
 	// Conditionally add dependencies from projects
 	if (findProject(':hl7-parser')) {
-		dependsOn(':hl7-parser:jar')
+		dependsOn(':hl7-parser:copyJar')
 	}
 
 	if (findProject(':cdaschema')) {

--- a/hl7-parser/build.gradle
+++ b/hl7-parser/build.gradle
@@ -39,5 +39,5 @@ task copyJar(type: Copy) {
   into "${project(':data-ingestion-service').projectDir}/libs/"
 }
 
-build.dependsOn copyJar
+build.finalizedBy(copyJar)
 


### PR DESCRIPTION
## Notes

Fixes the gradle build to work locally when data-ingestion `/libs` is not already present, and hopefully fixes the docker container build.

Last action to fail: https://github.com/CDCgov/NEDSS-DataIngestion/actions/runs/12302291088
Build order (note `:cdaschema:copyJar NO-SOURCE`)
![image](https://github.com/user-attachments/assets/a0bd6868-4392-4490-8561-3e75c34f6a03)


1. The `cdaschema.jar` was failing to copy.
2. The gradle script was complaining about a dependency not being listed

Working local `./gradlew data-ingestion-service:buildNeeded -x test`
![image](https://github.com/user-attachments/assets/84c0186b-6721-43ff-a991-3e7f02cd3474)
