### PR TITLE
Build test

### DIFF
--- a/cdaschema/build.gradle
+++ b/cdaschema/build.gradle
@@ -63,4 +63,5 @@ task copyJar(type: Copy) {
   into "${project(':data-ingestion-service').projectDir}/libs/"
 }
 cdaSchemaJar.mustRunAfter compileJava
+copyJar.dependsOn(generateXmlBeans)
 generateXmlBeans.finalizedBy(copyJar)

--- a/data-ingestion-service/build.gradle
+++ b/data-ingestion-service/build.gradle
@@ -184,7 +184,7 @@ compileJava.dependsOn jaxb
 if (project != project.rootProject || project.hasProperty('remoteBuild')) {
 	compileJava.mustRunAfter(":hl7-parser:copyJar")
 	compileJava.mustRunAfter(":cdaschema:generateXmlBeans")
-  compileJava.dependsOn(":cdaschema:copyJar")
+	compileJava.dependsOn(":cdaschema:copyJar")
 }
 
 

--- a/data-ingestion-service/build.gradle
+++ b/data-ingestion-service/build.gradle
@@ -183,7 +183,8 @@ compileJava.dependsOn jaxb
 
 if (project != project.rootProject || project.hasProperty('remoteBuild')) {
 	compileJava.mustRunAfter(":hl7-parser:copyJar")
-	compileJava.mustRunAfter(":cdaschema:copyJar")
+	compileJava.mustRunAfter(":cdaschema:generateXmlBeans")
+  compileJava.dependsOn(":cdaschema:copyJar")
 }
 
 


### PR DESCRIPTION
## Notes

Attempt 2 at fixing the build failure for data-ingestion-service container.  Was able to reproduce github action build failure by fully cleaning local environment prior to build.

Completely cleaned local env and was able to successfully build using: 
```
rm -rf data-ingestion-service/libs && ./gradlew clean && ./gradlew :data-ingestion-service:buildNeeded -x test --no-daemon
```

Was able to build local docker container successfully using:
```
docker compose up data-ingestion-service --build
```

