### PR TITLE
Local development: `srte-data-service` docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: ./
       dockerfile: ./data-ingestion-service/Dockerfile
     ports:
-      - "8083:8081"
+      - "8081:8081"
     depends_on:
       broker:
         condition: service_started
@@ -17,6 +17,23 @@ services:
       - dataingestion.env
     environment:
       SPRING_KAFKA_BOOTSTRAPSERVERS: broker:29092
+    networks:
+      - dataingestion
+
+  srte-data-service:
+    build:
+      context: .
+      dockerfile: ./srte-data-service/Dockerfile
+    ports:
+      - 8084:8084
+    depends_on:
+      di-keycloak:
+        condition: service_started
+      di-mssql:
+        condition: service_healthy
+    container_name: srte-data-service
+    env_file:
+       - dataingestion.env
     networks:
       - dataingestion
 

--- a/docs/DevSetup.md
+++ b/docs/DevSetup.md
@@ -7,9 +7,9 @@ Following this guide will set up a fully functioning local development environme
       ```bash
       ./containers/build_classic.sh
       ```
-2. Start Keycloak, Kafka, and database container
+2. Start Keycloak, Kafka, SRTE data cache, and database container
       ```bash
-      docker compose up di-keycloak broker zookeeper di-mssql -d
+      docker compose up di-keycloak broker zookeeper di-mssql srte-data-service -d
       ```
 3. Start data-ingestion-service with gradle. Allows remote debugging using port `19040`
       ```bash
@@ -39,8 +39,9 @@ The docker compose file supports pulling information from a `.dataingestion.env`
 #### dataingestion.env - place at the project root, alongside the docker-compose.yml
 ```bash
 DI_AUTH_URI=http://di-keycloak:8080/realms/NBS;
+RTI_CACHE_AUTH_URI=http://di-keycloak:8080/realms/NBS
 
-NBS_DBSERVER=di-mssql:2433
+NBS_DBSERVER=di-mssql:1433
 NBS_DBUSER=sa
 NBS_DBPASSWORD=fake.fake.fake.1234
 KC_BOOTSTRAP_ADMIN_USERNAME=admin
@@ -78,6 +79,23 @@ spring:
       url: jdbc:sqlserver://localhost:2433;databaseName=NBS_ODSE;encrypt=true;trustServerCertificate=true;
     srte:
       url: jdbc:sqlserver://localhost:2433;databaseName=NBS_SRTE;encrypt=true;trustServerCertificate=true;
+
+features:
+  modernizedMatching:
+    enabled: true
+    url: http://localhost:8083/api/deduplication/
+
+cache:
+  clientId: di-keycloak-client
+  secret: OhBq1ar96aep8cnirHwkCNfgsO9yybZI
+  token: http://localhost:8084/data/api/auth/token
+  srte:
+    cacheString: http://localhost:8084/data/srte/cache/string
+    cacheContain: http://localhost:8084/data/srte/cache/contain
+    cacheObject: http://localhost:8084/data/srte/cache/object
+  odse:
+    localId: http://localhost:8084/data/odse/localId
+
 ```
 
 #### deduplication/src/main/resources/application-local.yaml

--- a/srte-data-service/Dockerfile
+++ b/srte-data-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21 as builder
+FROM amazoncorretto:21 AS builder
 WORKDIR /usr/src/srtedataservice
 #Copy project config
 COPY gradle gradle


### PR DESCRIPTION
## Notes

Adds a docker compose entry for the `srte-data-service` that is configured to use local `di-mssql` and `di-keycloak` containers as dependencies.

## Demo
![srte-container](https://github.com/user-attachments/assets/759e4221-d2ed-4c02-9206-842905b23539)
