### PR TITLE
Use ObjectProvider for service dependency

### DIFF
--- a/data-processing-service/src/main/java/gov/cdc/dataprocessing/service/implementation/person/PatientMatchingService.java
+++ b/data-processing-service/src/main/java/gov/cdc/dataprocessing/service/implementation/person/PatientMatchingService.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,14 +48,14 @@ public class PatientMatchingService extends PatientMatchingBaseService implement
       CachingValueService cachingValueService,
       PrepareAssocModelHelper prepareAssocModelHelper,
       @Value("${features.modernizedMatching.enabled:false}") boolean modernizedMatchingEnabled,
-      DeduplicationService deduplicationService) {
+      ObjectProvider<DeduplicationService> deduplicationService) {
     super(edxPatientMatchRepositoryUtil,
         entityHelper,
         patientRepositoryUtil,
         cachingValueService,
         prepareAssocModelHelper);
     this.modernizedMatchingEnabled = modernizedMatchingEnabled;
-    this.deduplicationService = deduplicationService;
+    this.deduplicationService = deduplicationService.getIfAvailable();
   }
 
   @Transactional

--- a/data-processing-service/src/main/java/gov/cdc/dataprocessing/service/implementation/person/matching/DeduplicationClient.java
+++ b/data-processing-service/src/main/java/gov/cdc/dataprocessing/service/implementation/person/matching/DeduplicationClient.java
@@ -1,15 +1,19 @@
 package gov.cdc.dataprocessing.service.implementation.person.matching;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
 
 @Configuration
+@ConditionalOnProperty(name = "${features.modernizedMatching.enabled}", havingValue = "true")
 public class DeduplicationClient {
 
-  @Bean("deduplicationRestClient")
-  public RestClient restClient(@Value("${features.modernizedMatching.url}") String modernizedMatchingUrl) {
-    return RestClient.builder().baseUrl(modernizedMatchingUrl).build();
+  @Bean
+  public DeduplicationService deduplicationService(
+      @Value("${features.modernizedMatching.url}") String modernizedMatchingUrl) {
+    return new DeduplicationService(RestClient.builder().baseUrl(modernizedMatchingUrl).build());
   }
+
 }

--- a/data-processing-service/src/main/java/gov/cdc/dataprocessing/service/implementation/person/matching/DeduplicationService.java
+++ b/data-processing-service/src/main/java/gov/cdc/dataprocessing/service/implementation/person/matching/DeduplicationService.java
@@ -1,17 +1,13 @@
 package gov.cdc.dataprocessing.service.implementation.person.matching;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
-@Component
 public class DeduplicationService {
 
   private RestClient restClient;
 
-  public DeduplicationService(
-      @Qualifier("deduplicationRestClient") RestClient restClient) {
+  public DeduplicationService(RestClient restClient) {
     this.restClient = restClient;
   }
 

--- a/data-processing-service/src/test/java/gov/cdc/dataprocessing/service/implementation/person/matching/DeduplicationClientTest.java
+++ b/data-processing-service/src/test/java/gov/cdc/dataprocessing/service/implementation/person/matching/DeduplicationClientTest.java
@@ -3,7 +3,6 @@ package gov.cdc.dataprocessing.service.implementation.person.matching;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.web.client.RestClient;
 
 class DeduplicationClientTest {
 
@@ -11,17 +10,17 @@ class DeduplicationClientTest {
   void setsBaseUrl() {
     DeduplicationClient client = new DeduplicationClient();
 
-    RestClient restClient = client.restClient("someUrl");
+    DeduplicationService service = client.deduplicationService("someUrl");
 
-    assertThat(restClient).isNotNull();
+    assertThat(service).isNotNull();
   }
 
   @Test
   void setsNullBaseUrl() {
     DeduplicationClient client = new DeduplicationClient();
 
-    RestClient restClient = client.restClient(null);
+    DeduplicationService service = client.deduplicationService(null);
 
-    assertThat(restClient).isNotNull();
+    assertThat(service).isNotNull();
   }
 }


### PR DESCRIPTION
## Notes
If `features.modernizedMatching.enabled` is `false`, no DeduplicationService or RestClient bean will be created. Causing a failure in the dependency injection.

This PR resolves this failure due to missing bean by using `ObjectProvider`.