### PR TITLE
Pass database credentials to sonar run for build-and-deploy

### DIFF
--- a/.github/workflows/Build-and-deploy-data-ingestion-and-processing.yaml
+++ b/.github/workflows/Build-and-deploy-data-ingestion-and-processing.yaml
@@ -19,6 +19,8 @@ jobs:
       CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
       PASSED_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
+      DATABASE_USER: ${{secrets.DATABASE_USER}}
+      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD}}
   call-build-microservice-container-workflow:
     name: Build Container
     needs: sonar_scan

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -11,6 +11,12 @@ on:
       SONAR_TOKEN:
         description: "Secret named SONAR_TOKEN that references the sonar token secret corresponding to the project in sonarcloud."
         required: true
+      DATABASE_USER:
+        description: "Test database username"
+        required: true
+      DATABASE_PASSWORD:
+        description: "Test database password"
+        required: true
   pull_request:
     paths:
       - "data-ingestion-service/**"


### PR DESCRIPTION
## Notes

Attempts to resolve test failures caused by invalid database credentials when triggering `sonar.yaml` from the `Build-and-deploy-data-ingestion-and-processing.yaml` workflow.

1. Pass secrets to sonar workflow call
2. Set database secrets as required in sonar workflow call.

I am not good at testing workflows prior to merging them in. Cannot guarantee this will fix.