### PR TITLE
RTI: added kafka error check for step 2 and step 3 -- addressing kafka reb…

### DIFF
--- a/data-ingestion-service/src/main/resources/db/di-service-001.sql
+++ b/data-ingestion-service/src/main/resources/db/di-service-001.sql
@@ -43,23 +43,6 @@ IF NOT EXISTS(
 IF NOT EXISTS(
         SELECT 'X'
         FROM INFORMATION_SCHEMA.TABLES
-        WHERE TABLE_NAME = 'elr_fhir')
-    BEGIN
-        CREATE TABLE elr_fhir
-        (
-            id             UNIQUEIDENTIFIER PRIMARY KEY DEFAULT NEWID(),
-            fhir_message   NVARCHAR(MAX) NOT NULL,
-            raw_message_id UNIQUEIDENTIFIER FOREIGN KEY REFERENCES elr_raw (id),
-            created_by     NVARCHAR(255) NOT NULL,
-            updated_by     NVARCHAR(255) NOT NULL,
-            created_on     DATETIME      NOT NULL       DEFAULT getdate(),
-            updated_on     DATETIME      NULL
-        );
-    END
-
-IF NOT EXISTS(
-        SELECT 'X'
-        FROM INFORMATION_SCHEMA.TABLES
         WHERE TABLE_NAME = 'elr_dlt')
     BEGIN
         CREATE TABLE elr_dlt

--- a/data-processing-service/src/main/java/gov/cdc/dataprocessing/cache/PropertyUtilCache.java
+++ b/data-processing-service/src/main/java/gov/cdc/dataprocessing/cache/PropertyUtilCache.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 public class PropertyUtilCache {
     public static ArrayList<Object> cachedHivList = new ArrayList<>();
 
-
-    public static int kafkaFailedCheck = 0;
+    public static int kafkaFailedCheckStep1 = 0;
+    public static int kafkaFailedCheckStep2 = 0;
+    public static int kafkaFailedCheckStep3 = 0;
 }

--- a/data-processing-service/src/main/java/gov/cdc/dataprocessing/service/implementation/manager/ManagerService.java
+++ b/data-processing-service/src/main/java/gov/cdc/dataprocessing/service/implementation/manager/ManagerService.java
@@ -154,16 +154,19 @@ public class ManagerService implements IManagerService {
                 throw new DataProcessingException("NBS Interface Data Not Exist");
             }
 
-            if (res.get().getRecordStatusCd().equalsIgnoreCase("RTI_SUCCESS_STEP_2")) {
-                if (PropertyUtilCache.kafkaFailedCheckStep2 == 100000) {
-                    PropertyUtilCache.kafkaFailedCheckStep2 = 0;
-                }
-                ++PropertyUtilCache.kafkaFailedCheckStep2; // NOSONAR
+            synchronized (PropertyUtilCache.class) {
+                if (res.get().getRecordStatusCd().equalsIgnoreCase("RTI_SUCCESS_STEP_2")) {
+                    if (PropertyUtilCache.kafkaFailedCheckStep2 == 100000) {
+                        PropertyUtilCache.kafkaFailedCheckStep2 = 0;
+                    }
+                    ++PropertyUtilCache.kafkaFailedCheckStep2; // NOSONAR
 
-                kafkaFailedCheck = true;
-                logger.info("Kafka failed check at Step 2: {}", PropertyUtilCache.kafkaFailedCheckStep2);
-                return;
+                    kafkaFailedCheck = true;
+                    logger.info("Kafka failed check at Step 2: {}", PropertyUtilCache.kafkaFailedCheckStep2);
+                    return;
+                }
             }
+
 
             if (edxLabInformationDto.isLabIsUpdateDRRQ()) {
                 edxLabInformationDto.setLabIsUpdateSuccess(true);
@@ -264,16 +267,20 @@ public class ManagerService implements IManagerService {
                 throw new DataProcessingException("NBS Interface Data Not Exist");
             }
 
-            if (res.get().getRecordStatusCd().equalsIgnoreCase("RTI_SUCCESS_STEP_3")) {
-                if (PropertyUtilCache.kafkaFailedCheckStep3 == 100000) {
-                    PropertyUtilCache.kafkaFailedCheckStep3 = 0;
-                }
-                ++PropertyUtilCache.kafkaFailedCheckStep3; // NOSONAR
+            synchronized (PropertyUtilCache.class)
+            {
+                if (res.get().getRecordStatusCd().equalsIgnoreCase("RTI_SUCCESS_STEP_3")) {
+                    if (PropertyUtilCache.kafkaFailedCheckStep3 == 100000) {
+                        PropertyUtilCache.kafkaFailedCheckStep3 = 0;
+                    }
+                    ++PropertyUtilCache.kafkaFailedCheckStep3; // NOSONAR
 
-                kafkaFailedCheck = true;
-                logger.info("Kafka failed check at Step 3: {}", PropertyUtilCache.kafkaFailedCheckStep3);
-                return;
+                    kafkaFailedCheck = true;
+                    logger.info("Kafka failed check at Step 3: {}", PropertyUtilCache.kafkaFailedCheckStep3);
+                    return;
+                }
             }
+
 
             PageActProxyContainer pageActProxyContainer = null;
             PamProxyContainer pamProxyVO = null;
@@ -414,17 +421,19 @@ public class ManagerService implements IManagerService {
             } else {
                 throw new DataProcessingException("NBS Interface Not Exist");
             }
+            synchronized (PropertyUtilCache.class) {
+                if (obj.get().getRecordStatusCd().toUpperCase().contains("SUCCESS")) {
+                    if (PropertyUtilCache.kafkaFailedCheckStep1 == 100000) {
+                        PropertyUtilCache.kafkaFailedCheckStep1 = 0;
+                    }
+                    ++PropertyUtilCache.kafkaFailedCheckStep1; // NOSONAR
 
-            if (obj.get().getRecordStatusCd().toUpperCase().contains("SUCCESS")) {
-                if (PropertyUtilCache.kafkaFailedCheckStep1 == 100000) {
-                    PropertyUtilCache.kafkaFailedCheckStep1 = 0;
+                    kafkaFailedCheck = true;
+                    logger.info("Kafka failed check : {}", PropertyUtilCache.kafkaFailedCheckStep1);
+                    return;
                 }
-                ++PropertyUtilCache.kafkaFailedCheckStep1; // NOSONAR
-
-                kafkaFailedCheck = true;
-                logger.info("Kafka failed check : {}", PropertyUtilCache.kafkaFailedCheckStep1);
-                return;
             }
+
             edxLabInformationDto.setStatus(NbsInterfaceStatus.Success);
             edxLabInformationDto.setUserName(AuthUtil.authUser.getUserId());
 

--- a/data-processing-service/src/main/java/gov/cdc/dataprocessing/service/implementation/manager/ManagerService.java
+++ b/data-processing-service/src/main/java/gov/cdc/dataprocessing/service/implementation/manager/ManagerService.java
@@ -407,7 +407,7 @@ public class ManagerService implements IManagerService {
     }
 
     @SuppressWarnings({"java:S6541", "java:S3776"})
-    private void processingELR(Integer data) {
+    protected void processingELR(Integer data) {
         logger.info("Interface Id: {}", data);
         NbsInterfaceModel nbsInterfaceModel = null;
         EdxLabInformationDto edxLabInformationDto = new EdxLabInformationDto();

--- a/data-processing-service/src/test/java/gov/cdc/dataprocessing/service/implementation/manager/ManagerServiceTest.java
+++ b/data-processing-service/src/test/java/gov/cdc/dataprocessing/service/implementation/manager/ManagerServiceTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.dataprocessing.service.implementation.manager;
 
 //import gov.cdc.dataprocessing.cache.SrteCache;
+import gov.cdc.dataprocessing.cache.PropertyUtilCache;
 import gov.cdc.dataprocessing.constant.DecisionSupportConstants;
 import gov.cdc.dataprocessing.constant.DpConstant;
 import gov.cdc.dataprocessing.constant.elr.EdxELRConstant;
@@ -1071,6 +1072,20 @@ class ManagerServiceTest {
     }
 
     @Test
+    void initiateStep1KafkaFailed_ResetCache() {
+        Integer nbsId = 1;
+        PropertyUtilCache.kafkaFailedCheckStep1 = 100000;
+        var nbs = new NbsInterfaceModel();
+        nbs.setNbsInterfaceUid(nbsId);
+        nbs.setRecordStatusCd("SUCCESS");
+        when(nbsInterfaceRepository.findByNbsInterfaceUid(nbsId)).thenReturn(Optional.ofNullable(nbs));
+        managerService.processingELR(nbsId);
+
+        verify(kafkaManagerProducer, times(0)).sendDataPhc(any());
+        PropertyUtilCache.kafkaFailedCheckStep1 = 0;
+    }
+
+    @Test
     void initiateStep2KafkaFailed() {
         Integer nbsId = 1;
 
@@ -1087,6 +1102,22 @@ class ManagerServiceTest {
     }
 
     @Test
+    void initiateStep2KafkaFailed_ResetCache() {
+        Integer nbsId = 1;
+        PropertyUtilCache.kafkaFailedCheckStep2 = 100000;
+        var nbs = new NbsInterfaceModel();
+        var phc = new PublicHealthCaseFlowContainer();
+        phc.setNbsInterfaceId(nbsId);
+        nbs.setNbsInterfaceUid(nbsId);
+        nbs.setRecordStatusCd(DpConstant.DP_SUCCESS_STEP_2);
+        when(nbsInterfaceRepository.findByNbsInterfaceUid(nbsId)).thenReturn(Optional.ofNullable(nbs));
+        managerService.initiatingInvestigationAndPublicHealthCase(phc);
+
+        verify(kafkaManagerProducer, times(0)).sendDataLabHandling(any());
+        PropertyUtilCache.kafkaFailedCheckStep2 = 0;
+    }
+
+    @Test
     void initiateStep3KafkaFailed() {
         Integer nbsId = 1;
 
@@ -1100,6 +1131,23 @@ class ManagerServiceTest {
 
         verify(kafkaManagerProducer, times(0)).sendDataEdxActivityLog(any());
 
+    }
+
+
+    @Test
+    void initiateStep3KafkaFailed_ResetCache() {
+        Integer nbsId = 1;
+        PropertyUtilCache.kafkaFailedCheckStep3 = 100000;
+        var nbs = new NbsInterfaceModel();
+        var phc = new PublicHealthCaseFlowContainer();
+        phc.setNbsInterfaceId(nbsId);
+        nbs.setNbsInterfaceUid(nbsId);
+        nbs.setRecordStatusCd(DpConstant.DP_SUCCESS_STEP_3);
+        when(nbsInterfaceRepository.findByNbsInterfaceUid(nbsId)).thenReturn(Optional.ofNullable(nbs));
+        managerService.initiatingLabProcessing(phc);
+
+        verify(kafkaManagerProducer, times(0)).sendDataEdxActivityLog(any());
+        PropertyUtilCache.kafkaFailedCheckStep3 = 0;
     }
 
 }


### PR DESCRIPTION
## Notes

Issue: Kafka rebalancing on high volume which resetting commit off set and force RTI to reingest the same kafka message  from specific point in time

This is part of the effort to improve RTI performance when processing large data set

This pr added a kafka error check to prevent the service from reapply the RTI to logic to those records


## JIRA

- **Related story**: [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNDE-2101?atlOrigin=eyJpIjoiNTgyODFlZDk1Mzk1NGZhYWJlZWQ1NjA0OTAwYjAzZjIiLCJwIjoiaiJ9)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?