### PR TITLE
Remove warnings for generated files

### DIFF
--- a/cdaschema/build.gradle
+++ b/cdaschema/build.gradle
@@ -62,6 +62,26 @@ task copyJar(type: Copy) {
   from "${buildDir}/libs/cda-schema.jar"
   into "${project(':data-ingestion-service').projectDir}/libs/"
 }
+
+task addSuppressWarnings {
+    dependsOn generateXmlBeans
+
+    doLast {
+        FileTree tree = fileTree(dir: "${buildDir}/generated-src")
+        tree.each { file ->
+            if (file.name.endsWith(".java")) {
+                String content = file.getText()
+                if (!content.contains("@SuppressWarnings")) {
+                    content = content.replace("public class", "@SuppressWarnings(\"all\")\npublic class")
+                    content = content.replace("public interface", "@SuppressWarnings(\"all\")\npublic interface")
+                    file.setText(content)
+                }
+            }
+        }
+    }
+}
+
 cdaSchemaJar.mustRunAfter compileJava
 copyJar.dependsOn(generateXmlBeans)
 generateXmlBeans.finalizedBy(copyJar)
+generateXmlBeans.finalizedBy(addSuppressWarnings)

--- a/data-ingestion-service/build.gradle
+++ b/data-ingestion-service/build.gradle
@@ -182,9 +182,16 @@ task jaxb {
 compileJava.dependsOn jaxb
 
 if (project != project.rootProject || project.hasProperty('remoteBuild')) {
-	compileJava.mustRunAfter(":hl7-parser:copyJar")
-	compileJava.mustRunAfter(":cdaschema:generateXmlBeans")
-	compileJava.dependsOn(":cdaschema:copyJar")
+  if (!file("${projectDir}/libs/hl7-parser-0.0.1-SNAPSHOT.jar").exists()) {
+	  compileJava.mustRunAfter(":hl7-parser:copyJar")
+    compileJava.dependsOn(":hl7-parser:copyJar")
+  }
+
+  if (!file("${projectDir}/libs/cda-schema.jar").exists()) {
+     compileJava.mustRunAfter(":cdaschema:generateXmlBeans")
+	   compileJava.dependsOn(":cdaschema:copyJar")
+  }
+	
 }
 
 
@@ -291,11 +298,11 @@ jar {
 
 
 	// Conditionally add dependencies from projects
-	if (findProject(':hl7-parser')) {
+	if (findProject(':hl7-parser') && !file("${projectDir}/libs/hl7-parser-0.0.1-SNAPSHOT.jar").exists()) {
 		dependsOn(':hl7-parser:copyJar')
 	}
 
-	if (findProject(':cdaschema')) {
+	if (findProject(':cdaschema') && !file("${projectDir}/libs/cda-schema.jar").exists()) {
     dependsOn(':cdaschema:copyJar')
 	}
 }

--- a/data-ingestion-service/build.gradle
+++ b/data-ingestion-service/build.gradle
@@ -299,7 +299,7 @@ jar {
 
 	// Conditionally add dependencies from projects
 	if (findProject(':hl7-parser') && !file("${projectDir}/libs/hl7-parser-0.0.1-SNAPSHOT.jar").exists()) {
-		dependsOn(':hl7-parser:copyJar')
+    dependsOn(':hl7-parser:copyJar')
 	}
 
 	if (findProject(':cdaschema') && !file("${projectDir}/libs/cda-schema.jar").exists()) {

--- a/data-ingestion-service/build.gradle
+++ b/data-ingestion-service/build.gradle
@@ -298,13 +298,13 @@ jar {
 
 
 	// Conditionally add dependencies from projects
-	if (findProject(':hl7-parser') && !file("${projectDir}/libs/hl7-parser-0.0.1-SNAPSHOT.jar").exists()) {
+  if (findProject(':hl7-parser') && !file("${projectDir}/libs/hl7-parser-0.0.1-SNAPSHOT.jar").exists()) {
     dependsOn(':hl7-parser:copyJar')
-	}
+  }
 
-	if (findProject(':cdaschema') && !file("${projectDir}/libs/cda-schema.jar").exists()) {
+  if (findProject(':cdaschema') && !file("${projectDir}/libs/cda-schema.jar").exists()) {
     dependsOn(':cdaschema:copyJar')
-	}
+  }
 }
 
 sonarqube {


### PR DESCRIPTION
## Notes

1. Adds gradle task to add `@SuppressWarnings` to auto generated files to reduce "noise" in warnings displayed in IDE (2k+ warnings to 584)
2. Prevent data-ingestion-service from always rebuilding `cda-schema` and `hl7-parser` projects

## JIRA

NA

## Checklist

- [ ] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?