### PR TITLE
Cnd 171 Ability to reseed

### DIFF
--- a/containers/db/initialize/restore.d/04-create-deduplication-db.sql
+++ b/containers/db/initialize/restore.d/04-create-deduplication-db.sql
@@ -37,3 +37,11 @@ CREATE TABLE match_candidates (
   mpi_person_id uniqueidentifier
 );
 GO
+
+CREATE TABLE deduplication_status (
+   job_name VARCHAR(255) PRIMARY KEY,  -- This can be used to track specific job statuses
+   last_processed_id BIGINT,           -- Tracks the last processed ID
+   status VARCHAR(1),                  -- Status: 'P' for processed, 'F' for failed, 'N' for not processed
+   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+GO

--- a/containers/db/initialize/restore.d/04-create-deduplication-db.sql
+++ b/containers/db/initialize/restore.d/04-create-deduplication-db.sql
@@ -10,9 +10,13 @@ GO
 IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'last_processed_id')
 BEGIN
 CREATE TABLE last_processed_id (
-          id BIGINT PRIMARY KEY,
-          last_processed_id BIGINT
+                                   id BIGINT PRIMARY KEY,
+                                   last_processed_id BIGINT
 );
+
+-- Insert default row with id = 1 and last_processed_id = NULL
+INSERT INTO last_processed_id (id, last_processed_id)
+VALUES (1, NULL);
 END
 GO
 

--- a/containers/db/initialize/restore.d/04-create-deduplication-db.sql
+++ b/containers/db/initialize/restore.d/04-create-deduplication-db.sql
@@ -38,10 +38,9 @@ CREATE TABLE match_candidates (
 );
 GO
 
-CREATE TABLE deduplication_status (
-   job_name VARCHAR(255) PRIMARY KEY,  -- This can be used to track specific job statuses
+CREATE TABLE seed_status (
+   job_name VARCHAR(255) PRIMARY KEY,  -- This can be used to track specific job statuses for seeding it is 'seed-job'
    last_processed_id BIGINT,           -- Tracks the last processed ID
-   status VARCHAR(1),                  -- Status: 'P' for processed, 'F' for failed, 'N' for not processed
    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 GO

--- a/containers/db/initialize/restore.d/04-create-deduplication-db.sql
+++ b/containers/db/initialize/restore.d/04-create-deduplication-db.sql
@@ -7,6 +7,14 @@ GO
 USE [deduplication];
 GO
 
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'last_processed_id')
+BEGIN
+CREATE TABLE last_processed_id (
+          id BIGINT PRIMARY KEY,
+          last_processed_id BIGINT
+);
+END
+GO
 
 CREATE TABLE data_element_configuration (
 	id int IDENTITY (1,1) PRIMARY KEY,
@@ -35,12 +43,5 @@ CREATE TABLE match_candidates (
   id bigint IDENTITY(1,1),
   person_uid bigint,
   mpi_person_id uniqueidentifier
-);
-GO
-
-CREATE TABLE seed_status (
-   job_name VARCHAR(255) PRIMARY KEY,  -- This can be used to track specific job statuses for seeding it is 'seed-job'
-   last_processed_id BIGINT,           -- Tracks the last processed ID
-   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 GO

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/JobConfig.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/JobConfig.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.seed;
 
+import gov.cdc.nbs.deduplication.seed.listener.LastProcessedIdListener;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
 import org.springframework.batch.core.job.builder.JobBuilder;
@@ -64,12 +65,13 @@ public class JobConfig {
 
   @Bean("seedJob")
   public Job seedJob(JobRepository jobRepository,
-      @Qualifier("readNbsWriteToMpi") Step step1,
-      @Qualifier("readMpiWriteDeduplication") Step step2) {
+                     @Qualifier("readNbsWriteToMpi") Step step1,
+                     @Qualifier("readMpiWriteDeduplication") Step step2,
+                     LastProcessedIdListener listener) {
     return new JobBuilder("Seed MPI", jobRepository)
-        .start(step1)
-        .next(step2)
-        .build();
+            .start(step1)
+            .next(step2)
+            .listener(listener) // Register the listener here
+            .build();
   }
-
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/SeedController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/SeedController.java
@@ -8,6 +8,7 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,15 +24,18 @@ public class SeedController {
   private final JobLauncher launcher;
   private final Job seedJob;
   private final NamedParameterJdbcTemplate deduplicationNamedJdbcTemplate;
+  private final NamedParameterJdbcTemplate nbsNamedJdbcTemplate;
 
   // Constructor Injection for NamedParameterJdbcTemplate
   public SeedController(
           final JobLauncher launcher,
           @Qualifier("seedJob") final Job seedJob,
-          NamedParameterJdbcTemplate deduplicationNamedJdbcTemplate) {
+          @Qualifier("deduplicationNamedTemplate") NamedParameterJdbcTemplate deduplicationNamedJdbcTemplate,
+          @Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsNamedJdbcTemplate) {
     this.launcher = launcher;
     this.seedJob = seedJob;
     this.deduplicationNamedJdbcTemplate = deduplicationNamedJdbcTemplate;
+    this.nbsNamedJdbcTemplate = nbsNamedJdbcTemplate;
   }
 
   @PostMapping
@@ -40,13 +44,27 @@ public class SeedController {
           JobInstanceAlreadyCompleteException,
           JobParametersInvalidException {
 
-    // Query seed_status table to get last_processed_id
-    String sql = "SELECT last_processed_id FROM seed_status WHERE job_name = 'seed-job'";
-    Long lastProcessedId = deduplicationNamedJdbcTemplate.queryForObject(sql, new HashMap<>(), Long.class);
+    // Query the last_processed_id table to get the last processed ID
+    String sql = "SELECT last_processed_id FROM last_processed_id";
+    Long lastProcessedId = null;
 
-    // If lastProcessedId is null (first time seeding), use a default value to start from the smallest ID
+    try {
+      System.out.println("Running SQL: " + sql);
+      lastProcessedId = deduplicationNamedJdbcTemplate.queryForObject(sql, new HashMap<>(), Long.class);
+    } catch (Exception e) {
+      System.out.println("No record found in last_processed_id table.");
+    }
+
+    // If lastProcessedId is null (first-time seeding), fetch the smallest person ID from the nbs.person table
     if (lastProcessedId == null) {
-      lastProcessedId = -1L; // or another value to indicate first-time seeding
+      String smallestIdSql = "SELECT MIN(person_uid) FROM person";
+      try {
+        System.out.println("Fetching smallest person ID from person table: " + smallestIdSql);
+        lastProcessedId = nbsNamedJdbcTemplate.queryForObject(smallestIdSql, new HashMap<>(), Long.class);
+      } catch (Exception e) {
+        System.err.println("Error fetching smallest person ID: " + e.getMessage());
+        throw new IllegalStateException("Could not retrieve the smallest person ID from the nbs.person table.", e);
+      }
     }
 
     // Add lastProcessedId to job parameters

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/SeedController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/SeedController.java
@@ -3,7 +3,6 @@ package gov.cdc.nbs.deduplication.seed;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
-import org.springframework.batch.core.JobParametersInvalidException;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
@@ -26,7 +25,6 @@ public class SeedController {
   private final NamedParameterJdbcTemplate deduplicationNamedJdbcTemplate;
   private final NamedParameterJdbcTemplate nbsNamedJdbcTemplate;
 
-  // Constructor Injection for NamedParameterJdbcTemplate
   public SeedController(
           final JobLauncher launcher,
           @Qualifier("seedJob") final Job seedJob,
@@ -40,39 +38,76 @@ public class SeedController {
 
   @PostMapping
   public void startSeed() throws Exception {
-    // After the first run, this should retrieve the last processed ID from the previous clustering
-    String sql = "SELECT last_processed_id FROM last_processed_id WHERE id = 1";
-    Long lastProcessedId = null;
-
-    try {
-      lastProcessedId = deduplicationNamedJdbcTemplate.queryForObject(sql, new HashMap<>(), Long.class);
-      System.out.println("Last processed ID from DB: " + lastProcessedId);
-    } catch (Exception e) {
-      System.out.println("No record found in last_processed_id table.");
-    }
+    Long lastProcessedId = getLastProcessedId();
 
     if (lastProcessedId == null) {
-      String smallestIdSql = "SELECT MIN(person_uid) FROM person";
-      try {
-        lastProcessedId = nbsNamedJdbcTemplate.queryForObject(smallestIdSql, new HashMap<>(), Long.class);
-        if (lastProcessedId == null) {
-          throw new IllegalStateException("No records found in the NBS database.");
-        }
-      } catch (Exception e) {
-        System.err.println("Error fetching smallest person ID: " + e.getMessage());
-        throw new IllegalStateException("Could not retrieve the smallest person ID from the nbs.person table.", e);
-      }
+      // First run: get the smallest person_id from NBS
+      lastProcessedId = getSmallestPersonId();
     }
 
-    // Log job parameters before starting
     System.out.println("Starting job with lastProcessedId: " + lastProcessedId);
 
+    // Pass the lastProcessedId to the job parameters
     JobParameters parameters = new JobParametersBuilder()
             .addLong("startTime", System.currentTimeMillis())
             .addLong("lastProcessedId", lastProcessedId)
             .toJobParameters();
 
     launcher.run(seedJob, parameters);
+
+    // After seeding, update the lastProcessedId to the largest person_id processed
+    Long largestProcessedId = getLargestProcessedId();
+    if (largestProcessedId != null) {
+      updateLastProcessedId(largestProcessedId);
+    }
   }
 
+  // Method to get the last processed ID from the database
+  private Long getLastProcessedId() {
+    String sql = "SELECT last_processed_id FROM last_processed_id WHERE id = 1";
+    try {
+      return deduplicationNamedJdbcTemplate.queryForObject(sql, new HashMap<>(), Long.class);
+    } catch (Exception e) {
+      System.out.println("No record found in last_processed_id table.");
+      return null; // No record found, means first run
+    }
+  }
+
+  // Method to get the smallest person_id from the NBS database
+  private Long getSmallestPersonId() {
+    String smallestIdSql = "SELECT MIN(person_uid) FROM person";
+    try {
+      return nbsNamedJdbcTemplate.queryForObject(smallestIdSql, new HashMap<>(), Long.class);
+    } catch (Exception e) {
+      System.err.println("Error fetching smallest person ID: " + e.getMessage());
+      throw new IllegalStateException("Could not retrieve the smallest person ID from the nbs.person table.", e);
+    }
+  }
+
+  // Method to get the largest processed person_id after the seeding job
+  private Long getLargestProcessedId() {
+    String largestIdSql = "SELECT MAX(person_uid) FROM person WHERE person_uid > :lastProcessedId";
+    HashMap<String, Object> params = new HashMap<>();
+    params.put("lastProcessedId", getLastProcessedId());
+    try {
+      return nbsNamedJdbcTemplate.queryForObject(largestIdSql, params, Long.class);
+    } catch (Exception e) {
+      System.err.println("Error fetching largest person ID: " + e.getMessage());
+      return null; // Handle the case where the largest ID could not be fetched
+    }
+  }
+
+  // Method to update the last processed ID in the database
+  private void updateLastProcessedId(Long largestProcessedId) {
+    String updateSql = "UPDATE last_processed_id SET last_processed_id = :largestProcessedId WHERE id = 1";
+    HashMap<String, Object> params = new HashMap<>();
+    params.put("largestProcessedId", largestProcessedId);
+
+    try {
+      deduplicationNamedJdbcTemplate.update(updateSql, params);
+      System.out.println("Updated lastProcessedId to: " + largestProcessedId);
+    } catch (Exception e) {
+      System.err.println("Error updating lastProcessedId: " + e.getMessage());
+    }
+  }
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/SeedController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/SeedController.java
@@ -9,9 +9,12 @@ import org.springframework.batch.core.repository.JobExecutionAlreadyRunningExcep
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
 
 @RestController
 @RequestMapping("/api/deduplication/seed")
@@ -19,23 +22,40 @@ public class SeedController {
 
   private final JobLauncher launcher;
   private final Job seedJob;
+  private final NamedParameterJdbcTemplate deduplicationNamedJdbcTemplate;
 
+  // Constructor Injection for NamedParameterJdbcTemplate
   public SeedController(
-      final JobLauncher launcher,
-      @Qualifier("seedJob") final Job seedJob) {
+          final JobLauncher launcher,
+          @Qualifier("seedJob") final Job seedJob,
+          NamedParameterJdbcTemplate deduplicationNamedJdbcTemplate) {
     this.launcher = launcher;
     this.seedJob = seedJob;
+    this.deduplicationNamedJdbcTemplate = deduplicationNamedJdbcTemplate;
   }
 
   @PostMapping
   public void startSeed() throws JobExecutionAlreadyRunningException,
-      JobRestartException,
-      JobInstanceAlreadyCompleteException,
-      JobParametersInvalidException {
+          JobRestartException,
+          JobInstanceAlreadyCompleteException,
+          JobParametersInvalidException {
+
+    // Query seed_status table to get last_processed_id
+    String sql = "SELECT last_processed_id FROM seed_status WHERE job_name = 'seed-job'";
+    Long lastProcessedId = deduplicationNamedJdbcTemplate.queryForObject(sql, new HashMap<>(), Long.class);
+
+    // If lastProcessedId is null (first time seeding), use a default value to start from the smallest ID
+    if (lastProcessedId == null) {
+      lastProcessedId = -1L; // or another value to indicate first-time seeding
+    }
+
+    // Add lastProcessedId to job parameters
     JobParameters parameters = new JobParametersBuilder()
-        .addLong("startTime", System.currentTimeMillis())
-        .toJobParameters();
+            .addLong("startTime", System.currentTimeMillis())
+            .addLong("lastProcessedId", lastProcessedId)
+            .toJobParameters();
+
+    // Run the seed job with the parameters
     launcher.run(seedJob, parameters);
   }
-
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/listener/LastProcessedIdListener.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/listener/LastProcessedIdListener.java
@@ -1,0 +1,47 @@
+package gov.cdc.nbs.deduplication.seed.listener;
+
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class LastProcessedIdListener implements JobExecutionListener {
+
+    private final NamedParameterJdbcTemplate deduplicationNamedJdbcTemplate;
+
+    public LastProcessedIdListener(@Qualifier("deduplicationNamedTemplate") NamedParameterJdbcTemplate jdbcTemplate) {
+        this.deduplicationNamedJdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
+            Long lastProcessedId = jobExecution.getJobParameters().getLong("lastProcessedId");
+            System.out.println("After Job - Last processed ID: " + lastProcessedId);  // Log the value
+
+            if (lastProcessedId != null) {
+                String updateSql = "UPDATE last_processed_id SET last_processed_id = :lastProcessedId where id =1";
+                Map<String, Object> params = new HashMap<>();
+                params.put("lastProcessedId", lastProcessedId);
+
+                int rowsUpdated = deduplicationNamedJdbcTemplate.update(updateSql, params);
+                System.out.println("Rows updated: " + rowsUpdated);  // Log number of rows affected
+                System.out.println("Successfully updated last_processed_id to: " + lastProcessedId);
+            } else {
+                System.err.println("Job completed, but no lastProcessedId found in job parameters.");
+            }
+        } else {
+            System.err.println("Job did not complete successfully. Status: " + jobExecution.getStatus());
+        }
+    }
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/listener/LastProcessedIdListener.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/listener/LastProcessedIdListener.java
@@ -27,15 +27,18 @@ public class LastProcessedIdListener implements JobExecutionListener {
     public void afterJob(JobExecution jobExecution) {
         if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
             Long lastProcessedId = jobExecution.getJobParameters().getLong("lastProcessedId");
-            System.out.println("After Job - Last processed ID: " + lastProcessedId);  // Log the value
+
+            // Log for debugging purposes
+            System.out.println("After job completion, lastProcessedId: " + lastProcessedId);
 
             if (lastProcessedId != null) {
-                String updateSql = "UPDATE last_processed_id SET last_processed_id = :lastProcessedId where id =1";
+                // Update the last_processed_id with the last processed ID
+                String updateSql = "UPDATE last_processed_id SET last_processed_id = :lastProcessedId WHERE id = 1";
                 Map<String, Object> params = new HashMap<>();
                 params.put("lastProcessedId", lastProcessedId);
 
                 int rowsUpdated = deduplicationNamedJdbcTemplate.update(updateSql, params);
-                System.out.println("Rows updated: " + rowsUpdated);  // Log number of rows affected
+                System.out.println("Rows updated: " + rowsUpdated);
                 System.out.println("Successfully updated last_processed_id to: " + lastProcessedId);
             } else {
                 System.err.println("Job completed, but no lastProcessedId found in job parameters.");

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/DeduplicationWriter.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/DeduplicationWriter.java
@@ -45,7 +45,7 @@ public class DeduplicationWriter implements ItemWriter<DeduplicationEntry> {
         .addValue("person_parent_uid", entry.nbsPersonParentId())
         .addValue("mpi_patient", entry.mpiPatientId())
         .addValue("mpi_person", entry.mpiPersonId())
-        .addValue("status", "U");
+        .addValue("status", "P");
   }
 
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/DeduplicationWriter.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/DeduplicationWriter.java
@@ -28,7 +28,7 @@ public class DeduplicationWriter implements ItemWriter<DeduplicationEntry> {
         (:person_uid, :person_parent_uid, :mpi_patient, :mpi_person, :status);
       """;
 
-  private static final String UPDATE_LAST_PROCESSED_ID = """
+  public static final String UPDATE_LAST_PROCESSED_ID = """
       UPDATE last_processed_id
       SET last_processed_id = :lastProcessedId
       WHERE id = 1
@@ -59,7 +59,7 @@ public class DeduplicationWriter implements ItemWriter<DeduplicationEntry> {
     }
   }
 
-  private void updateLastProcessedId(Long lastProcessedId) {
+  public void updateLastProcessedId(Long lastProcessedId) {
     SqlParameterSource params = new MapSqlParameterSource()
             .addValue("lastProcessedId", lastProcessedId);
 

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/DeduplicationWriter.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/DeduplicationWriter.java
@@ -8,6 +8,8 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import gov.cdc.nbs.deduplication.seed.model.DeduplicationEntry;
 
@@ -17,11 +19,19 @@ import java.util.List;
 @Component
 public class DeduplicationWriter implements ItemWriter<DeduplicationEntry> {
 
+  private static final Logger logger = LoggerFactory.getLogger(DeduplicationWriter.class);
+
   private static final String QUERY = """
       INSERT INTO nbs_mpi_mapping
         (person_uid, person_parent_uid, mpi_patient, mpi_person, status)
       VALUES
         (:person_uid, :person_parent_uid, :mpi_patient, :mpi_person, :status);
+      """;
+
+  private static final String UPDATE_LAST_PROCESSED_ID = """
+      UPDATE last_processed_id
+      SET last_processed_id = :lastProcessedId
+      WHERE id = 1
       """;
 
   private final NamedParameterJdbcTemplate template;
@@ -33,19 +43,44 @@ public class DeduplicationWriter implements ItemWriter<DeduplicationEntry> {
   @Override
   public void write(@NonNull Chunk<? extends DeduplicationEntry> chunk) throws Exception {
     List<SqlParameterSource> batchParams = new ArrayList<>();
-    for (DeduplicationEntry entry : chunk) {
+    Long lastProcessedId = null;  // To track the last processed ID in this batch
+
+    // Iterate through the chunk of items
+    for (DeduplicationEntry entry : chunk.getItems()) {
       batchParams.add(createParameterSource(entry));
+      // Track the last ID in the chunk (you could adjust this logic based on the clustering query result)
+      lastProcessedId = entry.nbsPersonId();  // Assuming nbsPersonId() is the ID you're using for clustering
     }
+
+    // Insert the batch into nbs_mpi_mapping
     template.batchUpdate(QUERY, batchParams.toArray(new SqlParameterSource[0]));
+
+    // After processing the batch, update the lastProcessedId in the database
+    if (lastProcessedId != null) {
+      updateLastProcessedId(lastProcessedId);  // Use the last ID from the chunk
+    }
+  }
+
+
+  private void updateLastProcessedId(Long lastProcessedId) {
+    SqlParameterSource params = new MapSqlParameterSource()
+            .addValue("lastProcessedId", lastProcessedId);
+
+    try {
+      // Assuming the last_processed_id table has one record (id = 1)
+      template.update(UPDATE_LAST_PROCESSED_ID, params);
+      logger.info("Successfully updated last_processed_id to: {}", lastProcessedId);
+    } catch (Exception e) {
+      logger.error("Error updating last_processed_id: {}", e.getMessage());
+    }
   }
 
   SqlParameterSource createParameterSource(DeduplicationEntry entry) {
     return new MapSqlParameterSource()
-        .addValue("person_uid", entry.nbsPersonId())
-        .addValue("person_parent_uid", entry.nbsPersonParentId())
-        .addValue("mpi_patient", entry.mpiPatientId())
-        .addValue("mpi_person", entry.mpiPersonId())
-        .addValue("status", "P");
+            .addValue("person_uid", entry.nbsPersonId())
+            .addValue("person_parent_uid", entry.nbsPersonParentId())
+            .addValue("mpi_patient", entry.mpiPatientId())
+            .addValue("mpi_person", entry.mpiPersonId())
+            .addValue("status", "P");
   }
-
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/PersonReader.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/PersonReader.java
@@ -6,6 +6,7 @@ import org.springframework.batch.item.database.JdbcPagingItemReader;
 import org.springframework.batch.item.database.PagingQueryProvider;
 import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import gov.cdc.nbs.deduplication.seed.mapper.NbsPersonMapper;
@@ -17,13 +18,22 @@ public class PersonReader extends JdbcPagingItemReader<NbsPerson> {
   private final NbsPersonMapper mapper = new NbsPersonMapper();
 
   public PersonReader(
-      @Qualifier("nbs") DataSource dataSource) throws Exception {
+          @Qualifier("nbs") DataSource dataSource,
+          @Value("${lastProcessedId:0}") Long lastProcessedId) throws Exception {
 
     SqlPagingQueryProviderFactoryBean provider = new SqlPagingQueryProviderFactoryBean();
     provider.setDataSource(dataSource);
     provider.setSelectClause("SELECT person_uid, person_parent_uid");
     provider.setFromClause("FROM person");
-    provider.setWhereClause("WHERE person_uid = person_parent_uid AND record_status_cd = 'ACTIVE' AND cd = 'PAT'");
+
+    // Dynamically create the WHERE clause
+    String whereClause = "WHERE person_uid = person_parent_uid AND record_status_cd = 'ACTIVE' AND cd = 'PAT'";
+
+    if (lastProcessedId != null && lastProcessedId > 0) {
+      whereClause += " AND person_uid > " + lastProcessedId;
+    }
+
+    provider.setWhereClause(whereClause);
     provider.setSortKey("person_uid");
 
     this.setName("nbsPersonReader");
@@ -35,5 +45,4 @@ public class PersonReader extends JdbcPagingItemReader<NbsPerson> {
     this.setRowMapper(mapper);
     this.setPageSize(10000);
   }
-
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/PersonReader.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/PersonReader.java
@@ -31,6 +31,8 @@ public class PersonReader extends JdbcPagingItemReader<NbsPerson> {
 
     if (lastProcessedId != null && lastProcessedId > 0) {
       whereClause += " AND person_uid > " + lastProcessedId;
+    } else {
+      whereClause += " AND person_uid > 0";
     }
 
     provider.setWhereClause(whereClause);

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/SeedWriter.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/SeedWriter.java
@@ -148,12 +148,6 @@ public class SeedWriter implements ItemWriter<NbsPerson> {
             AND p.person_uid > :lastProcessedId
             AND (m.status != 'P' OR m.status IS NULL);
         """;
-  private static final String UPDATE_LAST_PROCESSED_ID_QUERY = """
-    UPDATE last_processed_id_table
-    SET last_processed_id = :lastProcessedId
-    WHERE some_condition;
-""";
-
 
   private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
   private final MpiPersonMapper mapper = new MpiPersonMapper();

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/SeedWriter.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/step/SeedWriter.java
@@ -198,7 +198,6 @@ public class SeedWriter implements ItemWriter<NbsPerson> {
                     .addValue("lastProcessedId", lastProcessedId),
             mapper);
 
-
     Map<String, List<MpiPerson>> clusterDataMap = clusterEntries.stream()
             .collect(Collectors.groupingBy(MpiPerson::parent_id));
 

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/seed/JobConfigTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/seed/JobConfigTest.java
@@ -15,6 +15,8 @@ import gov.cdc.nbs.deduplication.seed.step.DeduplicationWriter;
 import gov.cdc.nbs.deduplication.seed.step.MpiReader;
 import gov.cdc.nbs.deduplication.seed.step.PersonReader;
 import gov.cdc.nbs.deduplication.seed.step.SeedWriter;
+import gov.cdc.nbs.deduplication.seed.listener.LastProcessedIdListener;
+
 
 @ExtendWith(MockitoExtension.class)
 class JobConfigTest {
@@ -30,13 +32,15 @@ class JobConfigTest {
   private JobRepository jobRepository;
   @Mock
   private PlatformTransactionManager transactionManager;
+  @Mock
+  private LastProcessedIdListener listener;
 
   @Test
   void buildsValidConfig() {
     JobConfig config = new JobConfig(personReader, seedWriter, mpiReader, deduplicationWriter);
     assertThat(config).isNotNull();
 
-    Job seedJob = config.seedJob(jobRepository, null, null);
+    Job seedJob = config.seedJob(jobRepository, null, null, listener);
     assertThat(seedJob).isNotNull();
 
   }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/seed/step/DeduplicationWriterTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/seed/step/DeduplicationWriterTest.java
@@ -3,6 +3,8 @@ package gov.cdc.nbs.deduplication.seed.step;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -77,4 +79,15 @@ class DeduplicationWriterTest {
     assertThat(source.getValue("mpi_patient")).isEqualTo(entry.mpiPatientId());
     assertThat(source.getValue("mpi_person")).isEqualTo(entry.mpiPersonId());
   }
+
+  @Test
+  void testUpdateLastProcessedId() {
+    // Test the update logic directly
+    DeduplicationWriter writer = new DeduplicationWriter(template);
+    writer.updateLastProcessedId(5L);
+
+    // Verify that the update method was called
+    verify(template).update(eq(DeduplicationWriter.UPDATE_LAST_PROCESSED_ID), any(SqlParameterSource.class));
+  }
+
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/seed/step/PersonReaderTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/seed/step/PersonReaderTest.java
@@ -31,7 +31,7 @@ class PersonReaderTest {
     when(connection.getMetaData()).thenReturn(metadata);
     when(metadata.getDatabaseProductName()).thenReturn("sql server");
 
-    final PersonReader reader = new PersonReader(dataSource);
+    final PersonReader reader = new PersonReader(dataSource, 0L);
     assertThat(reader).isNotNull();
   }
 

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/seed/step/SeedWriterTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/seed/step/SeedWriterTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import gov.cdc.nbs.deduplication.seed.mapper.MpiPersonMapper;
 import gov.cdc.nbs.deduplication.seed.model.NbsPerson;
+import gov.cdc.nbs.deduplication.seed.model.SeedRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -43,13 +46,13 @@ class SeedWriterTest {
 
   @Test
   void initializes() {
-    SeedWriter newWriter = new SeedWriter(jdbcTemplate,mapper, restClient);
+    SeedWriter newWriter = new SeedWriter(jdbcTemplate,mapper, restClient, 0L);
     assertThat(newWriter).isNotNull();
   }
 
   @Test
   void writesChunk() throws Exception {
-    final SeedWriter writer = new SeedWriter(jdbcTemplate, mapper, restClient);
+    final SeedWriter writer = new SeedWriter(jdbcTemplate, mapper, restClient, 0L);
 
     when(restClient.post()).thenReturn(uriSpec);
     when(uriSpec.uri("/seed")).thenReturn(bodySpec);
@@ -67,5 +70,4 @@ class SeedWriterTest {
 
     verify(restClient, times(1)).post();
   }
-
 }


### PR DESCRIPTION
## Notes

We need to run the seed process for only some records from the DB instead of all the records in DB.

Ex: We have 100 records in DB and we are processing 10 records per batch for total 10 batches. If 7 batches are successful and moved 70 records to MPI we need the ability to run the 30 records as separate batch and move to MPI instead of re-running the seed process for all 100 records

## JIRA

- **Related story**: [[Jira Ticket](url)](https://cdc-nbs.atlassian.net/jira/software/c/projects/CND/boards/141?selectedIssue=CND-171)

## Checklist

- [ ] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?