### PR TITLE
Adding batch job for De-duplication.

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/DeduplicationApplication.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/DeduplicationApplication.java
@@ -2,12 +2,14 @@ package gov.cdc.nbs.deduplication;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class DeduplicationApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(DeduplicationApplication.class, args);
-	}
+  public static void main(String[] args) {
+    SpringApplication.run(DeduplicationApplication.class, args);
+  }
 
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/BatchJobConfig.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/BatchJobConfig.java
@@ -1,0 +1,53 @@
+package gov.cdc.nbs.deduplication.duplicates;
+
+import gov.cdc.nbs.deduplication.duplicates.model.MatchCandidate;
+import gov.cdc.nbs.deduplication.duplicates.step.DuplicatesProcessor;
+import gov.cdc.nbs.deduplication.duplicates.step.UnprocessedPersonReader;
+import gov.cdc.nbs.deduplication.duplicates.step.MatchCandidateWriter;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+public class BatchJobConfig {
+
+  private final UnprocessedPersonReader duplicatesReader;
+  private final DuplicatesProcessor deduplicationProcessor;
+  private final MatchCandidateWriter writer;
+
+  @Value("${batch.chunk.size.deduplicationStep:100}")
+  private int chunkSize;
+
+  public BatchJobConfig(
+      final UnprocessedPersonReader duplicatesReader,
+      final DuplicatesProcessor deduplicationProcessor,
+      final MatchCandidateWriter writer) {
+    this.duplicatesReader = duplicatesReader;
+    this.deduplicationProcessor = deduplicationProcessor;
+    this.writer = writer;
+  }
+
+  @Bean("deduplicationStep")
+  public Step step1(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+    return new StepBuilder("step1", jobRepository)
+        .<String, MatchCandidate>chunk(chunkSize, transactionManager) // Use externalized chunk size
+        .reader(duplicatesReader) // Read unprocessed MPI records
+        .processor(deduplicationProcessor) // Process records to find possible duplicates
+        .writer(writer) // Write match candidates and update status
+        .build();
+  }
+
+  @Bean("deduplicationJob")
+  public Job deduplicationJob(JobRepository jobRepository, @Qualifier("deduplicationStep") Step step1) {
+    return new JobBuilder("deduplication job", jobRepository)
+        .start(step1)
+        .build();
+  }
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/BatchJobScheduler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/BatchJobScheduler.java
@@ -1,0 +1,42 @@
+package gov.cdc.nbs.deduplication.duplicates;
+
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BatchJobScheduler {
+
+  private final JobLauncher jobLauncher;
+  private final Job deduplicationJob;
+
+  @Value("${batch.job.schedule.cron:0 0 1 * * ?}") // Default to daily at 1 AM
+  private String cronSchedule;
+
+  public BatchJobScheduler(JobLauncher jobLauncher, Job deduplicationJob) {
+    this.jobLauncher = jobLauncher;
+    this.deduplicationJob = deduplicationJob;
+  }
+
+  @Scheduled(cron = "#{@batchJobScheduler.cronSchedule}")
+  public void runJob()
+      throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException,
+      JobRestartException {
+    JobParameters params = new JobParametersBuilder()
+        .addLong("time", System.currentTimeMillis())
+        .toJobParameters();
+    jobLauncher.run(deduplicationJob, params);
+  }
+
+  public String getCronSchedule() {
+    return cronSchedule;
+  }
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/TestController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/TestController.java
@@ -1,0 +1,38 @@
+package gov.cdc.nbs.deduplication.duplicates;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/batch-job/test")
+public class TestController {
+
+  private final JobLauncher jobLauncher;
+  private final Job deduplicationJob;
+
+  public TestController(final JobLauncher jobLauncher, final Job deduplicationJob) {
+    this.jobLauncher = jobLauncher;
+    this.deduplicationJob = deduplicationJob;
+  }
+
+  @GetMapping
+  public void testBatchJob()
+      throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException,
+      JobRestartException {
+    JobParameters params = new JobParametersBuilder()
+        .addLong("time", System.currentTimeMillis())
+        .toJobParameters();
+    jobLauncher.run(deduplicationJob, params);
+  }
+
+
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/model/LinkResult.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/model/LinkResult.java
@@ -1,0 +1,14 @@
+package gov.cdc.nbs.deduplication.duplicates.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+public record LinkResult(
+    @JsonProperty("person_reference_id") UUID personReferenceId,
+    @JsonProperty("belongingness_ratio")
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    double belongingnessRatio
+) {
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/model/MatchCandidate.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/model/MatchCandidate.java
@@ -1,0 +1,6 @@
+package gov.cdc.nbs.deduplication.duplicates.model;
+
+import java.util.List;
+
+public record MatchCandidate(String nbsId, List<String> possibleMatchNbsId) {
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/model/MatchRequest.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/model/MatchRequest.java
@@ -1,0 +1,11 @@
+package gov.cdc.nbs.deduplication.duplicates.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import gov.cdc.nbs.deduplication.seed.model.MpiPerson;
+
+public record MatchRequest(
+    @JsonProperty("record") MpiPerson mpiPerson,
+    @JsonProperty("external_person_id") String externalPersonId,
+    @JsonProperty("algorithm") String algorithm
+) {
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/model/MatchResponse.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/model/MatchResponse.java
@@ -1,0 +1,41 @@
+package gov.cdc.nbs.deduplication.duplicates.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.List;
+import java.util.UUID;
+
+public record MatchResponse(
+    @JsonProperty("prediction") Prediction prediction,
+    @JsonProperty("person_reference_id") UUID personReferenceId,
+    @JsonProperty("results") List<LinkResult> results
+) {
+  public enum Prediction {
+    MATCH("match"),
+    POSSIBLE_MATCH("possible_match"),
+    NO_MATCH("no_match");
+
+    private final String value;
+
+    Prediction(String value) {
+      this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+      return value;
+    }
+
+    @JsonCreator
+    public static Prediction fromValue(String value) {
+      for (Prediction prediction : Prediction.values()) {
+        if (prediction.value.equals(value)) {
+          return prediction;
+        }
+      }
+      throw new IllegalArgumentException("Unknown value: " + value);
+    }
+  }
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/service/DuplicateCheckService.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/service/DuplicateCheckService.java
@@ -1,0 +1,29 @@
+package gov.cdc.nbs.deduplication.duplicates.service;
+
+import gov.cdc.nbs.deduplication.duplicates.model.MatchRequest;
+import gov.cdc.nbs.deduplication.duplicates.model.MatchResponse;
+import gov.cdc.nbs.deduplication.seed.model.MpiPerson;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.http.MediaType;
+
+@Service
+public class DuplicateCheckService {
+
+  private final RestClient recordLinkageClient;
+
+  public DuplicateCheckService(@Qualifier("recordLinkageRestClient") RestClient recordLinkageClient) {
+    this.recordLinkageClient = recordLinkageClient;
+  }
+
+  public MatchResponse findDuplicateRecords(MpiPerson personRecord) {
+    return recordLinkageClient.post()
+        .uri("/match")
+        .contentType(MediaType.APPLICATION_JSON)
+        .accept(MediaType.APPLICATION_JSON)
+        .body(new MatchRequest(personRecord, personRecord.parent_id(), null))
+        .retrieve()
+        .body(MatchResponse.class);
+  }
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/service/PatientRecordService.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/service/PatientRecordService.java
@@ -1,0 +1,140 @@
+package gov.cdc.nbs.deduplication.duplicates.service;
+
+import gov.cdc.nbs.deduplication.seed.mapper.MpiPersonMapper;
+import gov.cdc.nbs.deduplication.seed.model.MpiPerson;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class PatientRecordService {
+
+  private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+  private final MpiPersonMapper mpiPersonMapper = new MpiPersonMapper();
+
+  private static final String PATIENT_DETAILS_QUERY = """
+      SELECT
+          p.person_uid external_id,
+          p.person_parent_uid,
+          cast(p.birth_time as Date) birth_date,
+          p.curr_sex_cd sex,
+          p.additional_gender_cd gender,
+          nested.address,
+          nested.phone,
+          nested.name,
+          nested.identifiers,
+          nested.race,
+          p.last_chg_time -- Add last_chg_time to the query
+      FROM
+          person p WITH (NOLOCK)
+          OUTER apply (
+              SELECT
+                  *
+              FROM
+                  -- address
+                  (
+                      SELECT
+                          (
+                              SELECT
+                                  STRING_ESCAPE(pl.street_addr1, 'json') street,
+                                  STRING_ESCAPE(pl.street_addr2, 'json') street2,
+                                  city_desc_txt city,
+                                  sc.code_desc_txt state,
+                                  zip_cd zip,
+                                  scc.code_desc_txt county
+                              FROM
+                                  Entity_locator_participation elp WITH (NOLOCK)
+                                  JOIN Postal_locator pl WITH (NOLOCK) ON elp.locator_uid = pl.postal_locator_uid
+                                  LEFT JOIN NBS_SRTE.dbo.state_code sc ON sc.state_cd = pl.state_cd
+                                  LEFT JOIN NBS_SRTE.dbo.state_county_code_value scc ON scc.code = pl.cnty_cd
+                              WHERE
+                                  elp.entity_uid = p.person_uid
+                                  AND elp.class_cd = 'PST'
+                                  AND elp.status_cd = 'A'
+                                  AND pl.street_addr1 IS NOT NULL FOR json path
+                          ) AS address
+                  ) AS address,
+                  -- identifiers
+                  (
+                      SELECT
+                          (
+                              SELECT
+                                  eid.type_cd type,
+                                  STRING_ESCAPE(REPLACE(REPLACE(eid.root_extension_txt,'-',''),' ',''), 'json') value,
+                                  eid.assigning_authority_cd authority
+                              FROM
+                                  entity_id eid WITH (NOLOCK)
+                              WHERE
+                                  eid.entity_uid = p.person_uid FOR json path
+                          ) AS identifiers
+                  ) AS identifiers,
+                  -- person races
+                  (
+                      SELECT
+                          (
+                              SELECT TOP 1
+                                  pr.race_category_cd value
+                              FROM
+                                  Person_race pr WITH (NOLOCK)
+                              WHERE
+                                  person_uid = p.person_uid
+                          ) AS race
+                  ) AS race,
+                  -- person phone
+                  (
+                      SELECT
+                          (
+                              SELECT
+                                  REPLACE(REPLACE(tl.phone_nbr_txt,'-',''),' ','') value
+                              FROM
+                                  Entity_locator_participation elp WITH (NOLOCK)
+                                  JOIN Tele_locator tl WITH (NOLOCK) ON elp.locator_uid = tl.tele_locator_uid
+                              WHERE
+                                  elp.entity_uid = p.person_uid
+                                  AND elp.class_cd = 'TELE'
+                                  AND elp.status_cd = 'A'
+                                  AND tl.phone_nbr_txt IS NOT NULL FOR json path
+                          ) AS phone
+                  ) AS phone,
+                  -- person_names
+                  (
+                      SELECT
+                          (
+                              SELECT
+                                  STRING_ESCAPE(REPLACE(pn.last_nm,'-',' '), 'json') lastNm,
+                                  STRING_ESCAPE(pn.middle_nm, 'json') middleNm,
+                                  STRING_ESCAPE(pn.first_nm, 'json') firstNm,
+                                  pn.nm_suffix nmSuffix
+                              FROM
+                                  person_name pn WITH (NOLOCK)
+                              WHERE
+                                  person_uid = p.person_uid FOR json path
+                          ) AS name
+                  ) AS name
+          ) AS nested
+      WHERE
+          p.person_parent_uid = :personParentUid
+          AND p.record_status_cd = 'ACTIVE'
+      ORDER BY p.last_chg_time DESC
+      """;
+
+  public PatientRecordService(
+      @Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate namedParameterJdbcTemplate
+  ) {
+    this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
+  }
+
+  public MpiPerson fetchPatientDetails(String personParentUid) {
+    MapSqlParameterSource params = new MapSqlParameterSource()
+        .addValue("personParentUid", personParentUid);
+
+    List<MpiPerson> mpiPersons = namedParameterJdbcTemplate.query(
+        PATIENT_DETAILS_QUERY,
+        params,
+        mpiPersonMapper);
+    return (mpiPersons.isEmpty()) ? null : mpiPersons.getFirst();// most recent based on last_chg_time
+  }
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/step/DuplicatesProcessor.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/step/DuplicatesProcessor.java
@@ -1,0 +1,45 @@
+package gov.cdc.nbs.deduplication.duplicates.step;
+
+import gov.cdc.nbs.deduplication.duplicates.model.LinkResult;
+import gov.cdc.nbs.deduplication.duplicates.model.MatchCandidate;
+import gov.cdc.nbs.deduplication.duplicates.model.MatchResponse;
+import gov.cdc.nbs.deduplication.duplicates.service.PatientRecordService;
+import gov.cdc.nbs.deduplication.duplicates.service.DuplicateCheckService;
+import gov.cdc.nbs.deduplication.seed.model.MpiPerson;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class DuplicatesProcessor implements ItemProcessor<String, MatchCandidate> {
+
+  private final PatientRecordService patientRecordService;
+  private final DuplicateCheckService recordLinkerService;
+
+  public DuplicatesProcessor(
+      final PatientRecordService patientRecordService,
+      final DuplicateCheckService recordLinkerService) {
+    this.patientRecordService = patientRecordService;
+    this.recordLinkerService = recordLinkerService;
+  }
+
+  @Override
+  public MatchCandidate process(String personUid) {
+
+    MpiPerson patientRecord = patientRecordService.fetchPatientDetails(personUid);
+    MatchResponse response = recordLinkerService.findDuplicateRecords(patientRecord);
+
+    // Process only "possible_match" responses for manual review
+    if (MatchResponse.Prediction.POSSIBLE_MATCH == response.prediction()) {
+      List<String> possibleMatchNbsIds = response.results().stream()
+          .map(LinkResult::personReferenceId)
+          .map(UUID::toString)
+          .toList();
+
+      return new MatchCandidate(personUid, possibleMatchNbsIds);
+    }
+    return new MatchCandidate(personUid, null);
+  }
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/step/MatchCandidateWriter.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/step/MatchCandidateWriter.java
@@ -1,0 +1,72 @@
+package gov.cdc.nbs.deduplication.duplicates.step;
+
+import gov.cdc.nbs.deduplication.duplicates.model.MatchCandidate;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Component
+public class MatchCandidateWriter implements ItemWriter<MatchCandidate> {
+
+  private static final String MATCH_CANDIDATES_QUERY = """
+      INSERT INTO match_candidates (nbs_id, possible_match_nbs_id)
+      VALUES (:nbsId, :possibleMatchNbsId)
+      """;
+
+  private static final String NBS_MAPPING_QUERY = """
+      UPDATE nbs_mpi_mapping
+      SET status = 'P'
+      WHERE person_uid IN (:personIds)
+      """;
+
+  private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+  @Autowired
+  public MatchCandidateWriter(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
+    this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
+  }
+
+  @Override
+  public void write(Chunk<? extends MatchCandidate> chunk) {
+    List<String> personIds = new ArrayList<>();
+    List<MatchCandidate> candidatesToInsert = new ArrayList<>();
+    for (MatchCandidate candidate : chunk.getItems()) {
+      personIds.add(candidate.nbsId());
+      if (candidate.possibleMatchNbsId() != null) {
+        candidatesToInsert.add(candidate);
+      }
+    }
+    insertMatchCandidates(candidatesToInsert);
+    updateStatus(personIds);
+  }
+
+  private void insertMatchCandidates(List<MatchCandidate> candidates) {
+    List<MapSqlParameterSource> batchParams = new ArrayList<>();
+    for (MatchCandidate candidate : candidates) {
+      for (String possibleMatchNbsId : candidate.possibleMatchNbsId()) {
+        batchParams.add(new MapSqlParameterSource()
+            .addValue("nbsId", candidate.nbsId())
+            .addValue("possibleMatchNbsId", possibleMatchNbsId));
+      }
+    }
+    if (!batchParams.isEmpty()) {
+      namedParameterJdbcTemplate.batchUpdate(MATCH_CANDIDATES_QUERY, batchParams.toArray(new MapSqlParameterSource[0]));
+    }
+  }
+
+  private void updateStatus(List<String> personIds) {
+    if (!personIds.isEmpty()) {
+      MapSqlParameterSource parameters = new MapSqlParameterSource();
+      parameters.addValue("personIds", personIds);
+      namedParameterJdbcTemplate.update(NBS_MAPPING_QUERY, parameters);
+    }
+  }
+
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/step/UnprocessedPersonReader.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/step/UnprocessedPersonReader.java
@@ -1,0 +1,31 @@
+package gov.cdc.nbs.deduplication.duplicates.step;
+
+import javax.sql.DataSource;
+
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.PagingQueryProvider;
+import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UnprocessedPersonReader extends JdbcPagingItemReader<String> {
+
+  public UnprocessedPersonReader(@Qualifier("deduplication") DataSource dataSource) throws Exception {
+    SqlPagingQueryProviderFactoryBean provider = new SqlPagingQueryProviderFactoryBean();
+    provider.setDataSource(dataSource);
+    provider.setSelectClause("SELECT person_uid");
+    provider.setFromClause("FROM nbs_mpi_mapping");
+    provider.setWhereClause("WHERE status = 'U' AND person_uid=person_parent_uid");
+    provider.setSortKey("person_uid");
+
+    this.setName("unprocessedPersonUidReader");
+    this.setDataSource(dataSource);
+    PagingQueryProvider queryProvider = provider.getObject();
+    if (queryProvider != null) {
+      this.setQueryProvider(queryProvider);
+    }
+    this.setRowMapper((rs, rowNum) -> rs.getString("person_uid"));
+    this.setPageSize(1000);
+  }
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/JobConfig.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/JobConfig.java
@@ -27,10 +27,10 @@ public class JobConfig {
   final MpiReader mpiReader;
   final DeduplicationWriter deduplicationWriter;
 
-  @Value("${batch.chunk.size.step1:100}") // Default value is 100
+  @Value("${batch.chunk.size.readNbsWriteToMpi:100}")
   private int step1ChunkSize;
 
-  @Value("${batch.chunk.size.step2:1000}") // Default value for step2
+  @Value("${batch.chunk.size.readMpiWriteDeduplication:1000}")
   private int step2ChunkSize;
 
   public JobConfig(

--- a/deduplication/src/main/resources/application.yaml
+++ b/deduplication/src/main/resources/application.yaml
@@ -30,11 +30,18 @@ spring:
       username: ${MPI_DB_USERNAME}
       password: ${MPI_DB_PASSWORD}
 
+  main:
+    allow-circular-references: true
+
 recordLinkage:
   url: ${RECORD_LINKER_URL}
 
 batch:
   chunk:
     size:
-      step1: 100
-      step2: 1000
+      readNbsWriteToMpi: 100
+      readMpiWriteDeduplication: 1000
+      deduplicationStep: 100
+  job:
+    schedule:
+      cron: "0 0 1 * * ?"  # run daily at 1 AM

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/BatchJobConfigTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/BatchJobConfigTest.java
@@ -1,0 +1,51 @@
+package gov.cdc.nbs.deduplication.duplicates;
+
+import gov.cdc.nbs.deduplication.duplicates.step.DuplicatesProcessor;
+import gov.cdc.nbs.deduplication.duplicates.step.UnprocessedPersonReader;
+import gov.cdc.nbs.deduplication.duplicates.step.MatchCandidateWriter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class BatchJobConfigTest {
+
+  @Mock
+  private UnprocessedPersonReader duplicatesReader;
+
+  @Mock
+  private DuplicatesProcessor deduplicationProcessor;
+
+  @Mock
+  private MatchCandidateWriter writer;
+
+  @Mock
+  private JobRepository jobRepository;
+
+  @Mock
+  private PlatformTransactionManager transactionManager;
+
+  @Test
+  void buildsValidConfig() {
+    BatchJobConfig config = new BatchJobConfig(duplicatesReader, deduplicationProcessor, writer);
+    assertThat(config).isNotNull();
+
+    Job deduplicationJob = config.deduplicationJob(jobRepository, null);
+    assertThat(deduplicationJob).isNotNull();
+  }
+
+  @Test
+  void deduplicationStep() {
+    BatchJobConfig config = new BatchJobConfig(duplicatesReader, deduplicationProcessor, writer);
+
+    Step step1 = config.step1(jobRepository, transactionManager);
+    assertThat(step1).isNotNull();
+  }
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/BatchJobSchedulerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/BatchJobSchedulerTest.java
@@ -1,0 +1,39 @@
+package gov.cdc.nbs.deduplication.duplicates;
+
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+
+@ExtendWith(MockitoExtension.class)
+class BatchJobSchedulerTest {
+
+  @Mock
+  private JobLauncher jobLauncher;
+
+  @Mock
+  private Job deduplicationJob;
+
+  @InjectMocks
+  private BatchJobScheduler batchJobScheduler;
+
+  @Test
+  void runJobTest() throws Exception {
+    batchJobScheduler.runJob();
+
+    ArgumentCaptor<JobParameters> captor = forClass(JobParameters.class);
+    verify(jobLauncher, times(1)).run(eq(deduplicationJob), captor.capture());
+
+    JobParameters capturedParams = captor.getValue();
+    assertThat(capturedParams.getLong("time")).isNotNull();
+  }
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/TestControllerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/TestControllerTest.java
@@ -1,0 +1,33 @@
+package gov.cdc.nbs.deduplication.duplicates;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+
+
+@ExtendWith(MockitoExtension.class)
+class TestControllerTest {
+
+  @Mock
+  private JobLauncher jobLauncher;
+
+  @Mock
+  private Job deduplicationJob;
+
+  @InjectMocks
+  private TestController testController;
+
+  @Test
+  void testBatchJob() throws Exception {
+    testController.testBatchJob();
+    verify(jobLauncher, times(1)).run(eq(deduplicationJob), any(JobParameters.class));
+  }
+
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/service/DuplicateCheckServiceTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/service/DuplicateCheckServiceTest.java
@@ -1,0 +1,71 @@
+package gov.cdc.nbs.deduplication.duplicates.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import gov.cdc.nbs.deduplication.duplicates.model.LinkResult;
+import gov.cdc.nbs.deduplication.duplicates.model.MatchRequest;
+import gov.cdc.nbs.deduplication.duplicates.model.MatchResponse;
+import gov.cdc.nbs.deduplication.seed.model.MpiPerson;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+import org.springframework.web.client.RestClient.RequestBodySpec;
+import org.springframework.web.client.RestClient.RequestBodyUriSpec;
+import org.springframework.web.client.RestClient.ResponseSpec;
+
+import java.util.List;
+import java.util.UUID;
+
+@ExtendWith(MockitoExtension.class)
+class DuplicateCheckServiceTest {
+
+  @Mock
+  private RestClient recordLinkageClient;
+
+  @Mock
+  private RequestBodyUriSpec uriSpec;
+
+  @Mock
+  private RequestBodySpec bodySpec;
+
+  @Mock
+  private ResponseSpec responseSpec;
+
+  @InjectMocks
+  private DuplicateCheckService duplicateCheckService;
+
+
+  @Test
+  void findDuplicateRecordsTest() {
+    MpiPerson personRecord = new MpiPerson(null, null, null, null, null,
+        null, null, null, null, null);
+
+    LinkResult linkResult1 = new LinkResult(UUID.randomUUID(), 0.85);
+    LinkResult linkResult2 = new LinkResult(UUID.randomUUID(), 0.90);
+    MatchResponse expectedResponse = new MatchResponse(
+        MatchResponse.Prediction.POSSIBLE_MATCH,
+        UUID.randomUUID(),
+        List.of(linkResult1, linkResult2)
+    );
+
+    when(recordLinkageClient.post()).thenReturn(uriSpec);
+    when(uriSpec.uri("/match")).thenReturn(bodySpec);
+    when(bodySpec.accept(MediaType.APPLICATION_JSON)).thenReturn(bodySpec);
+    when(bodySpec.contentType(MediaType.APPLICATION_JSON)).thenReturn(bodySpec);
+    when(bodySpec.body(any(MatchRequest.class))).thenReturn(bodySpec);
+    when(bodySpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.body(MatchResponse.class)).thenReturn(expectedResponse);
+
+    MatchResponse actualResponse = duplicateCheckService.findDuplicateRecords(personRecord);
+
+    assertThat(actualResponse).isEqualTo(expectedResponse);
+  }
+
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/service/PatientRecordServiceTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/service/PatientRecordServiceTest.java
@@ -1,0 +1,59 @@
+package gov.cdc.nbs.deduplication.duplicates.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import gov.cdc.nbs.deduplication.seed.mapper.MpiPersonMapper;
+import gov.cdc.nbs.deduplication.seed.model.MpiPerson;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.Collections;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class PatientRecordServiceTest {
+
+  @Mock
+  private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+  @InjectMocks
+  private PatientRecordService patientRecordService;
+
+
+  @Test
+  void fetchPatientDetailsReturnsMpiPerson() {
+    String personParentUid = "123";
+    MpiPerson expectedPerson = new MpiPerson(null, null, null, null, null,
+        null, null, null, null, null);
+    List<MpiPerson> mpiPersons = Collections.singletonList(expectedPerson);
+
+    when(namedParameterJdbcTemplate.query(any(String.class), any(MapSqlParameterSource.class),
+        any(MpiPersonMapper.class)))
+        .thenReturn(mpiPersons);
+
+    MpiPerson actualPerson = patientRecordService.fetchPatientDetails(personParentUid);
+
+    assertThat(actualPerson).isEqualTo(expectedPerson);
+  }
+
+
+  @Test
+  void fetchPatientDetailsReturnsNullWhenNoRecordsFound() {
+    String personParentUid = "123";
+    List<MpiPerson> mpiPersons = Collections.emptyList();
+
+    when(namedParameterJdbcTemplate.query(any(String.class), any(MapSqlParameterSource.class),
+        any(MpiPersonMapper.class)))
+        .thenReturn(mpiPersons);
+
+    MpiPerson actualPerson = patientRecordService.fetchPatientDetails(personParentUid);
+    assertThat(actualPerson).isNull();
+  }
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/step/DuplicatesProcessorTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/step/DuplicatesProcessorTest.java
@@ -1,0 +1,98 @@
+package gov.cdc.nbs.deduplication.duplicates.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import gov.cdc.nbs.deduplication.duplicates.model.LinkResult;
+import gov.cdc.nbs.deduplication.duplicates.model.MatchCandidate;
+import gov.cdc.nbs.deduplication.duplicates.model.MatchResponse;
+import gov.cdc.nbs.deduplication.duplicates.service.DuplicateCheckService;
+import gov.cdc.nbs.deduplication.duplicates.service.PatientRecordService;
+import gov.cdc.nbs.deduplication.seed.model.MpiPerson;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+@ExtendWith(MockitoExtension.class)
+class DuplicatesProcessorTest {
+
+  @Mock
+  private PatientRecordService patientRecordService;
+
+  @Mock
+  private DuplicateCheckService recordLinkerService;
+
+  @InjectMocks
+  private DuplicatesProcessor duplicatesProcessor;
+
+  @Test
+  void processReturnsMatchCandidateForPossibleMatch() {
+    String personUid = "1234";
+    MpiPerson patientRecord = new MpiPerson(null, null, null, null, null,
+        null, null, null, null, null);
+    MatchResponse response = mock(MatchResponse.class);
+    LinkResult linkResult = mock(LinkResult.class);
+    List<LinkResult> linkResults = Collections.singletonList(linkResult);
+
+    when(patientRecordService.fetchPatientDetails(personUid)).thenReturn(patientRecord);
+    when(recordLinkerService.findDuplicateRecords(any(MpiPerson.class))).thenReturn(response);
+    when(response.prediction()).thenReturn(MatchResponse.Prediction.POSSIBLE_MATCH);
+    when(response.results()).thenReturn(linkResults);
+    when(linkResult.personReferenceId()).thenReturn(UUID.randomUUID());
+
+    MatchCandidate result = duplicatesProcessor.process(personUid);
+
+    assertThat(result).isNotNull();
+    assertThat(result.nbsId()).isEqualTo(personUid);
+    assertThat(result.possibleMatchNbsId()).isNotNull();
+    assertThat(result.possibleMatchNbsId()).hasSize(1);
+  }
+
+
+
+  @Test
+  void processReturnsMatchCandidateWithNullForNoMatch() {
+    String personUid = "1234";
+    MpiPerson patientRecord = new MpiPerson(null, null, null, null, null,
+        null, null, null, null, null);
+    MatchResponse response = mock(MatchResponse.class);
+
+    when(patientRecordService.fetchPatientDetails(personUid)).thenReturn(patientRecord);
+    when(recordLinkerService.findDuplicateRecords(patientRecord)).thenReturn(response);
+    when(response.prediction()).thenReturn(MatchResponse.Prediction.NO_MATCH);
+
+    MatchCandidate result = duplicatesProcessor.process(personUid);
+
+    assertThat(result).isNotNull();
+    assertThat(result.nbsId()).isEqualTo(personUid);
+    assertThat(result.possibleMatchNbsId()).isNull();
+  }
+
+
+  @Test
+  void processReturnsMatchCandidateWithNullForMatch() {
+    String personUid = "1234";
+    MpiPerson patientRecord = new MpiPerson(null, null, null, null, null,
+        null, null, null, null, null);
+    MatchResponse response = mock(MatchResponse.class);
+
+    when(patientRecordService.fetchPatientDetails(personUid)).thenReturn(patientRecord);
+    when(recordLinkerService.findDuplicateRecords(any(MpiPerson.class))).thenReturn(response);
+    when(response.prediction()).thenReturn(MatchResponse.Prediction.MATCH);
+
+    MatchCandidate result = duplicatesProcessor.process(personUid);
+
+    assertThat(result).isNotNull();
+    assertThat(result.nbsId()).isEqualTo(personUid);
+    assertThat(result.possibleMatchNbsId()).isNull();
+  }
+
+
+
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/step/MatchCandidateWriterTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/step/MatchCandidateWriterTest.java
@@ -1,0 +1,63 @@
+package gov.cdc.nbs.deduplication.duplicates.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import gov.cdc.nbs.deduplication.duplicates.model.MatchCandidate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.item.Chunk;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ExtendWith(MockitoExtension.class)
+class MatchCandidateWriterTest {
+
+  @Mock
+  private NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+  @InjectMocks
+  private MatchCandidateWriter writer;
+
+  @Test
+  void initializes() {
+    MatchCandidateWriter newWriter = new MatchCandidateWriter(namedParameterJdbcTemplate);
+    assertThat(newWriter).isNotNull();
+  }
+
+  @Test
+  void writesChunkWithPossibleMatches() {
+    List<MatchCandidate> candidates = new ArrayList<>();
+    candidates.add(new MatchCandidate("nbsId1", List.of("possibleMatch1")));
+    candidates.add(new MatchCandidate("nbsId2", List.of("possibleMatch2", "possibleMatch3")));
+    var chunk = new Chunk<>(candidates);
+
+    writer.write(chunk);
+
+    verify(namedParameterJdbcTemplate, times(1)).batchUpdate(Mockito.anyString(),
+        Mockito.any(MapSqlParameterSource[].class));
+    verify(namedParameterJdbcTemplate, times(1)).update(Mockito.anyString(), any(MapSqlParameterSource.class));
+  }
+
+
+  @Test
+  void writesChunkWithNoPossibleMatches() {
+    List<MatchCandidate> candidates = new ArrayList<>();
+    candidates.add(new MatchCandidate("nbsId1", null)); // No possible matches
+    var chunk = new Chunk<>(candidates);
+
+    writer.write(chunk);
+
+    verify(namedParameterJdbcTemplate, never()).batchUpdate(Mockito.anyString(),
+        Mockito.any(MapSqlParameterSource[].class));
+    verify(namedParameterJdbcTemplate, times(1)).update(Mockito.anyString(), any(MapSqlParameterSource.class));
+  }
+
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/step/UnprocessedPersonReaderTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/step/UnprocessedPersonReaderTest.java
@@ -1,0 +1,36 @@
+package gov.cdc.nbs.deduplication.duplicates.step;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UnprocessedPersonReaderTest {
+
+  @Mock
+  private DataSource dataSource;
+
+  @Mock
+  private Connection connection;
+
+  @Mock
+  private DatabaseMetaData metadata;
+
+  @Test
+  void initializesReader() throws Exception {
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.getMetaData()).thenReturn(metadata);
+    when(metadata.getDatabaseProductName()).thenReturn("sql server");
+
+    final UnprocessedPersonReader reader = new UnprocessedPersonReader(dataSource);
+    assertThat(reader).isNotNull();
+  }
+}


### PR DESCRIPTION

Implemented batch job for deduplication processing. The job reads unprocessed patient records, processes them to identify potential duplicates, and writes match candidates

## JIRA

https://cdc-nbs.atlassian.net/browse/CND-163