### PR TITLE
CND-194 export api and unit test

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmController.java
@@ -5,10 +5,10 @@ import gov.cdc.nbs.deduplication.algorithm.dto.Pass;
 import gov.cdc.nbs.deduplication.algorithm.model.MatchingConfigRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.ByteArrayInputStream;
@@ -24,6 +24,7 @@ import java.util.Map;
 public class AlgorithmController {
 
     private final AlgorithmService algorithmService;
+
     private final ObjectMapper objectMapper;
 
     private static final Logger log = LoggerFactory.getLogger(AlgorithmController.class);
@@ -73,6 +74,7 @@ public class AlgorithmController {
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName)
                 .body(new InputStreamResource(byteArrayInputStream));
+    }
 
     @PostMapping("/import-configuration")
     public ResponseEntity<String> importConfiguration(@RequestBody MatchingConfigRequest configRequest) {

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmController.java
@@ -5,16 +5,15 @@ import gov.cdc.nbs.deduplication.algorithm.dto.Pass;
 import gov.cdc.nbs.deduplication.algorithm.model.MatchingConfigRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -54,26 +53,25 @@ public class AlgorithmController {
     public void updateAlgorithm(@RequestBody MatchingConfigRequest request) {
         algorithmService.updateDibbsConfigurations(request);
     }
+
     @GetMapping("/export-configuration")
-    public ResponseEntity<Resource> exportConfiguration() throws IOException {
+    public ResponseEntity<InputStreamResource> exportConfiguration() throws IOException {
+        // Fetch the configuration from the service
         List<Pass> passes = algorithmService.getMatchingConfiguration();
 
-        // Generate timestamped filename
+        // Convert to JSON string
+        String jsonConfig = objectMapper.writeValueAsString(passes);
+
+        // Convert to bytes and create an InputStream
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(jsonConfig.getBytes(StandardCharsets.UTF_8));
+
+        // Generate a timestamped filename
         String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
         String fileName = "record_linker_config_" + timestamp + ".json";
-        String tempDir = System.getProperty("java.io.tmpdir");
-        Path filePath = Paths.get(tempDir, fileName);
 
-        // Convert the list of passes to JSON and save as a file
-        objectMapper.writeValue(filePath.toFile(), passes);
-
-        log.info("File exported to : {}", filePath);
-
-        // serving the file for download
-        Resource file = new FileSystemResource(filePath);
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName)
-                .body(file);
+                .body(new InputStreamResource(byteArrayInputStream));
     }
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmController.java
@@ -1,11 +1,22 @@
 package gov.cdc.nbs.deduplication.algorithm;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cdc.nbs.deduplication.algorithm.dto.Pass;
 import gov.cdc.nbs.deduplication.algorithm.model.MatchingConfigRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
@@ -14,11 +25,13 @@ import java.util.Map;
 public class AlgorithmController {
 
     private final AlgorithmService algorithmService;
+    private final ObjectMapper objectMapper;
 
     private static final Logger log = LoggerFactory.getLogger(AlgorithmController.class);
 
-    public AlgorithmController(final AlgorithmService algorithmService) {
+    public AlgorithmController(AlgorithmService algorithmService, ObjectMapper objectMapper) {
         this.algorithmService = algorithmService;
+        this.objectMapper = objectMapper;
     }
 
     @PostMapping("/configure-matching")
@@ -40,5 +53,27 @@ public class AlgorithmController {
     @PostMapping("/update-algorithm")
     public void updateAlgorithm(@RequestBody MatchingConfigRequest request) {
         algorithmService.updateDibbsConfigurations(request);
+    }
+    @GetMapping("/export-configuration")
+    public ResponseEntity<Resource> exportConfiguration() throws IOException {
+        List<Pass> passes = algorithmService.getMatchingConfiguration();
+
+        // Generate timestamped filename
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        String fileName = "record_linker_config_" + timestamp + ".json";
+        String tempDir = System.getProperty("java.io.tmpdir");
+        Path filePath = Paths.get(tempDir, fileName);
+
+        // Convert the list of passes to JSON and save as a file
+        objectMapper.writeValue(filePath.toFile(), passes);
+
+        log.info("File exported to : {}", filePath);
+
+        // serving the file for download
+        Resource file = new FileSystemResource(filePath);
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName)
+                .body(file);
     }
 }


### PR DESCRIPTION
## Notes

When managing the Record Linker algorithm configuration, STLTs are expected to test the algorithm in a dev or test environment. Once the algorithm is finalized, the configuration will need to be migrated to the production environment.

Providing simple APIs for importing and exporting the configuration will ease this process.

## JIRA

- **Related story**: [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CND-194?atlOrigin=eyJpIjoiYWJlZjk3YTUyN2YyNDBlODljY2FhZjgzNjc0NDU1MDYiLCJwIjoiaiJ9)

## Checklist

- [x] PR focuses on a single story.
- [x] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

![EXPORTapi](https://github.com/user-attachments/assets/fb5ca1e6-e190-4356-be89-5d0f950d7950)

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?