### PR TITLE
cnd-195-import api and unit test

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmController.java
@@ -4,6 +4,7 @@ import gov.cdc.nbs.deduplication.algorithm.dto.Pass;
 import gov.cdc.nbs.deduplication.algorithm.model.MatchingConfigRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,7 +18,7 @@ public class AlgorithmController {
 
     private static final Logger log = LoggerFactory.getLogger(AlgorithmController.class);
 
-    public AlgorithmController(final AlgorithmService algorithmService) {
+    public AlgorithmController(AlgorithmService algorithmService) {
         this.algorithmService = algorithmService;
     }
 
@@ -40,5 +41,11 @@ public class AlgorithmController {
     @PostMapping("/update-algorithm")
     public void updateAlgorithm(@RequestBody MatchingConfigRequest request) {
         algorithmService.updateDibbsConfigurations(request);
+    }
+
+    @PostMapping("/import-configuration")
+    public ResponseEntity<String> importConfiguration(@RequestBody MatchingConfigRequest configRequest) {
+        algorithmService.saveMatchingConfiguration(configRequest);
+        return ResponseEntity.ok("Configuration imported successfully.");
     }
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmControllerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmControllerTest.java
@@ -1,18 +1,30 @@
 package gov.cdc.nbs.deduplication.algorithm;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cdc.nbs.deduplication.algorithm.dto.Pass;
 import gov.cdc.nbs.deduplication.algorithm.model.MatchingConfigRequest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
 
 import java.util.List;
 import java.util.Map;
 
+import static com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.io.support.ClassicRequestBuilder.post;
 import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 class AlgorithmControllerTest {
@@ -22,6 +34,16 @@ class AlgorithmControllerTest {
 
     @InjectMocks
     private AlgorithmController algorithmController;
+
+    private ObjectMapper objectMapper;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        mockMvc = MockMvcBuilders.standaloneSetup(algorithmController).build();
+    }
 
     @Test
     void testConfigureMatching() {
@@ -108,5 +130,29 @@ class AlgorithmControllerTest {
         algorithmController.updateAlgorithm(request);
 
         verify(algorithmService, times(1)).updateDibbsConfigurations(request);
+    }
+
+    @Test
+    void testImportConfiguration() throws Exception {
+        // Prepare mock data
+        MatchingConfigRequest mockConfigRequest = new MatchingConfigRequest(
+                "Test Label",
+                "Test Description",
+                true,
+                true,
+                List.of()
+        );
+
+        doNothing().when(algorithmService).saveMatchingConfiguration(mockConfigRequest);
+
+        String jsonRequest = objectMapper.writeValueAsString(mockConfigRequest);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/deduplication/import-configuration")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonRequest))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().string("Configuration imported successfully."));
+
+        verify(algorithmService).saveMatchingConfiguration(mockConfigRequest);
     }
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmControllerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmControllerTest.java
@@ -14,17 +14,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-
 
 import java.util.List;
 import java.util.Map;
 
-import static com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.io.support.ClassicRequestBuilder.post;
 import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 class AlgorithmControllerTest {


### PR DESCRIPTION
## Notes

When managing the Record Linker algorithm configuration, STLTs are expected to test the algorithm in a dev or test environment. Once the algorithm is finalized, the configuration will need to be migrated to the production environment.
Providing simple APIs for importing and exporting the configuration will ease this process.

![IMPORT](https://github.com/user-attachments/assets/4837d8e6-a261-4d93-880b-f375598ef5b4)

## JIRA

- **Related story**: [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CND-195)

## Checklist

- [x] PR focuses on a single story.
- [x] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?