### PR TITLE
Update record linker 25.2.0

### DIFF
--- a/containers/record-linker/Dockerfile
+++ b/containers/record-linker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cdcgov/recordlinker:v25.1.0
+FROM ghcr.io/cdcgov/recordlinker:v25.2.0
 
 
 # Install drivers for mssql database connection

--- a/deduplication/src/main/resources/application.yaml
+++ b/deduplication/src/main/resources/application.yaml
@@ -34,7 +34,7 @@ spring:
     allow-circular-references: true
 
 recordLinkage:
-  url: http://localhost:8080
+  url: http://localhost:8062
 
 batch:
   chunk:

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmServiceTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmServiceTest.java
@@ -160,6 +160,7 @@ class AlgorithmServiceTest {
     }
 
     @Test
+    @SuppressWarnings(value = {"rawtypes", "unchecked"})
     void testFetchDefaultConfiguration_Success() {
         RestClient.RequestHeadersUriSpec mockRequestHeadersUriSpec = mock(RestClient.RequestHeadersUriSpec.class);
         RestClient.ResponseSpec mockResponseSpec = mock(RestClient.ResponseSpec.class);
@@ -186,6 +187,7 @@ class AlgorithmServiceTest {
 
 
     @Test
+    @SuppressWarnings(value = {"rawtypes", "unchecked"})
     void testFetchDefaultConfiguration_ApiFailure() {
         RestClient.RequestHeadersUriSpec mockRequestHeadersUriSpec = mock(RestClient.RequestHeadersUriSpec.class);
         RestClient.ResponseSpec mockResponseSpec = mock(RestClient.ResponseSpec.class);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
     build: ./containers/record-linker
     container_name: record-linker
     ports:
-     - "8080:8080"
+     - "8062:8080"
     environment:
       DB_URI: "mssql+pyodbc://sa:${NBS_DBPASSWORD:-fake.fake.fake.1234}@di-mssql:1433/mpi?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes"
     networks:


### PR DESCRIPTION
## Notes

1. Updates record linker container to latest:  v25.2.0
2. Updates port for RL container to be `8062` to not conflict with modernization-api
3. Fixes a few warnings in a test


## JIRA

- **Related story**: [CND-224](https://cdc-nbs.atlassian.net/browse/CND-224)

## Checklist

- [x] PR focuses on a single story.
- [x] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [x] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?

[CND-224]: https://cdc-nbs.atlassian.net/browse/CND-224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ