### PR TITLE
CND-227: Export/Import Configuration with Data Elements

### DIFF
--- a/data-processing-service/src/main/resources/application.yaml
+++ b/data-processing-service/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ cache:
 
 features:
   modernizedMatching:
-    enabled: ${MODERNIZED_MATCHING_ENABLED:false}
+    enabled: ${MODERNIZED_MATCHING_ENABLED:true}
     url: ${MODERNIZED_MATCHING_URL}
 
 spring:

--- a/data-processing-service/src/main/resources/application.yaml
+++ b/data-processing-service/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ cache:
 
 features:
   modernizedMatching:
-    enabled: ${MODERNIZED_MATCHING_ENABLED:true}
+    enabled: ${MODERNIZED_MATCHING_ENABLED:false}
     url: ${MODERNIZED_MATCHING_URL}
 
 spring:

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmService.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cdc.nbs.deduplication.algorithm.dto.AlgorithmPass;
 import gov.cdc.nbs.deduplication.algorithm.dto.Evaluator;
+import gov.cdc.nbs.deduplication.algorithm.dto.Kwargs;
 import gov.cdc.nbs.deduplication.algorithm.dto.Pass;
 import gov.cdc.nbs.deduplication.algorithm.mapper.AlgorithmConfigMapper;
 import gov.cdc.nbs.deduplication.algorithm.mapper.AlgorithmRequestMapper;
@@ -21,7 +22,6 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
-import java.util.HashMap;
 import java.util.List;
 
 @Service
@@ -100,7 +100,7 @@ public class AlgorithmService {
                             List.of("BIRTHDATE", "ADDRESS", "ZIP"),
                             List.of(new Evaluator("FIRST_NAME", "func:recordlinker.linking.matchers.compare_fuzzy_match")),
                             "func:recordlinker.linking.matchers.rule_match",
-                            new HashMap<>()
+                            new Kwargs(null, null, null, null)
                     ))
             );
 

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/dto/AlgorithmPass.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/dto/AlgorithmPass.java
@@ -7,5 +7,5 @@ public record AlgorithmPass(
         @JsonProperty("blocking_keys") List<String> blockingKeys,
         @JsonProperty("evaluators") List<Evaluator> evaluators,
         @JsonProperty("rule") String rule,
-        @JsonProperty("kwargs") Object kwargs
+        @JsonProperty("kwargs") Kwargs kwargs
 ) {}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/dto/Kwargs.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/dto/Kwargs.java
@@ -1,0 +1,12 @@
+package gov.cdc.nbs.deduplication.algorithm.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record Kwargs(
+        String similarityMeasure,
+        Map<String, Double> thresholds,
+        Double trueMatchThreshold,
+        Map<String, Double> logOdds
+) {}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/dto/Kwargs.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/dto/Kwargs.java
@@ -1,12 +1,11 @@
 package gov.cdc.nbs.deduplication.algorithm.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public record Kwargs(
-        String similarityMeasure,
-        Map<String, Double> thresholds,
-        Double trueMatchThreshold,
-        Map<String, Double> logOdds
+        @JsonProperty("similarity_measure") String similarityMeasure,
+        @JsonProperty("thresholds") Map<String, Double> thresholds,
+        @JsonProperty("true_match_threshold") Double trueMatchThreshold,
+        @JsonProperty("log_odds") Map<String, Double> logOdds
 ) {}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/dto/Pass.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/dto/Pass.java
@@ -9,5 +9,6 @@ public record Pass (
         String lowerBound,
         String upperBound,
         Map<String, Boolean> blockingCriteria, // Map instead of List
-        List<MatchingCriteria> matchingCriteria
+        List<MatchingCriteria> matchingCriteria,
+        Kwargs kwargs
 ) {}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/dto/Pass.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/dto/Pass.java
@@ -1,5 +1,7 @@
 package gov.cdc.nbs.deduplication.algorithm.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
 import java.util.List;
 import java.util.Map;
 
@@ -10,5 +12,5 @@ public record Pass (
         String upperBound,
         Map<String, Boolean> blockingCriteria, // Map instead of List
         List<MatchingCriteria> matchingCriteria,
-        Kwargs kwargs
+        @JsonDeserialize(as = Kwargs.class) Kwargs kwargs
 ) {}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/mapper/AlgorithmConfigMapper.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/mapper/AlgorithmConfigMapper.java
@@ -92,7 +92,8 @@ public class AlgorithmConfigMapper {
                             lowerBound,
                             upperBound,
                             mapBlockingCriteria(pass.blockingKeys()),
-                            mapMatchingCriteria(pass.evaluators())
+                            mapMatchingCriteria(pass.evaluators()),
+                            mapKwargs((Kwargs) pass.kwargs())
                     );
                 })
                 .toList();
@@ -107,5 +108,18 @@ public class AlgorithmConfigMapper {
         }
 
         return blockingMap;
+    }
+
+    private static Kwargs mapKwargs(Kwargs algorithmKwargs) {
+        if (algorithmKwargs == null) {
+            return null;
+        }
+
+        return new Kwargs(
+                algorithmKwargs.similarityMeasure(),
+                algorithmKwargs.thresholds(),
+                algorithmKwargs.trueMatchThreshold(),
+                algorithmKwargs.logOdds()
+        );
     }
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/mapper/AlgorithmConfigMapper.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/mapper/AlgorithmConfigMapper.java
@@ -135,7 +135,7 @@ public class AlgorithmConfigMapper {
     }
 
     @SuppressWarnings("unchecked")
-    private static Map<String, Double> castToMap(Object obj) {
+    public static Map<String, Double> castToMap(Object obj) {
         return obj instanceof Map<?, ?> ? (Map<String, Double>) obj : null;
     }
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/mapper/AlgorithmConfigMapper.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/mapper/AlgorithmConfigMapper.java
@@ -93,7 +93,7 @@ public class AlgorithmConfigMapper {
                             upperBound,
                             mapBlockingCriteria(pass.blockingKeys()),
                             mapMatchingCriteria(pass.evaluators()),
-                            mapKwargs((Kwargs) pass.kwargs())
+                            mapKwargs(pass.kwargs())
                     );
                 })
                 .toList();
@@ -110,16 +110,32 @@ public class AlgorithmConfigMapper {
         return blockingMap;
     }
 
-    private static Kwargs mapKwargs(Kwargs algorithmKwargs) {
-        if (algorithmKwargs == null) {
+    public static Kwargs mapKwargs(Object rawKwargs) {
+        if (rawKwargs == null) {
             return null;
         }
 
-        return new Kwargs(
-                algorithmKwargs.similarityMeasure(),
-                algorithmKwargs.thresholds(),
-                algorithmKwargs.trueMatchThreshold(),
-                algorithmKwargs.logOdds()
-        );
+        if (rawKwargs instanceof Kwargs kwargs) {
+            return kwargs;
+        }
+
+        if (rawKwargs instanceof Map<?, ?> kwargsMap) {
+
+            return new Kwargs(
+                    (String) kwargsMap.get("similarity_measure"),
+                    castToMap(kwargsMap.get("thresholds")),
+                    kwargsMap.get("true_match_threshold") instanceof Number
+                            ? ((Number) kwargsMap.get("true_match_threshold")).doubleValue()
+                            : null,
+                    castToMap(kwargsMap.get("log_odds"))
+            );
+        }
+
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Double> castToMap(Object obj) {
+        return obj instanceof Map<?, ?> ? (Map<String, Double>) obj : null;
     }
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/mapper/AlgorithmRequestMapper.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/mapper/AlgorithmRequestMapper.java
@@ -10,6 +10,8 @@ import gov.cdc.nbs.deduplication.algorithm.model.AlgorithmUpdateRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static gov.cdc.nbs.deduplication.algorithm.mapper.AlgorithmConfigMapper.mapKwargs;
+
 public class AlgorithmRequestMapper {
 
     private static final Logger log = LoggerFactory.getLogger(AlgorithmRequestMapper.class);
@@ -128,9 +130,10 @@ public class AlgorithmRequestMapper {
                 .toList()
                 : List.of(); // Empty list fallback
 
-        return new AlgorithmPass(new ArrayList<>(blockingKeys.keySet()), evaluators,
-                "func:recordlinker.linking.matchers.rule_match", new HashMap<>());
+        return new AlgorithmPass(new ArrayList<>(blockingKeys.keySet()),
+                evaluators,
+                "func:recordlinker.linking.matchers.rule_match",
+                mapKwargs(pass.kwargs())
+        );
     }
-
-
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmControllerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmControllerTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.deduplication.algorithm;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cdc.nbs.deduplication.algorithm.dto.Kwargs;
 import gov.cdc.nbs.deduplication.algorithm.dto.Pass;
 import gov.cdc.nbs.deduplication.algorithm.model.MatchingConfigRequest;
 import org.springframework.core.io.InputStreamResource;
@@ -52,13 +53,19 @@ class AlgorithmControllerTest {
                 "LAST_NAME", false
         );
 
+        Kwargs kwargs = new Kwargs("JaroWinkler",
+                Map.of("FIRST_NAME", 0.9, "LAST_NAME", 0.95),
+                12.2,
+                Map.of("FIRST_NAME", 6.85, "LAST_NAME", 6.35));
+
         List<Pass> passes = List.of(new Pass(
                 "TestPass",
                 "Description",
                 "0.1",
                 "0.9",
                 blockingCriteria,
-                List.of()
+                List.of(),
+                kwargs
         ));
 
         MatchingConfigRequest request = new MatchingConfigRequest(
@@ -83,13 +90,19 @@ class AlgorithmControllerTest {
                 "LAST_NAME", false
         );
 
+        Kwargs kwargs = new Kwargs("JaroWinkler",
+                Map.of("FIRST_NAME", 0.9, "LAST_NAME", 0.95),
+                12.2,
+                Map.of("FIRST_NAME", 6.85, "LAST_NAME", 6.35));
+
         List<Pass> passes = List.of(new Pass(
                 "TestPass",
                 "Description",
                 "0.1",
                 "0.9",
-                blockingCriteria, // Updated to Map<String, Boolean>
-                List.of()
+                blockingCriteria,
+                List.of(),
+                kwargs
         ));
 
         when(algorithmService.getMatchingConfiguration()).thenReturn(passes);
@@ -108,13 +121,19 @@ class AlgorithmControllerTest {
                 "LAST_NAME", false
         );
 
+        Kwargs kwargs = new Kwargs("JaroWinkler",
+                Map.of("FIRST_NAME", 0.9, "LAST_NAME", 0.95),
+                12.2,
+                Map.of("FIRST_NAME", 6.85, "LAST_NAME", 6.35));
+
         List<Pass> passes = List.of(new Pass(
                 "TestPass",
                 "Description",
                 "0.1",
                 "0.9",
-                blockingCriteria, // Updated to Map<String, Boolean>
-                List.of()
+                blockingCriteria,
+                List.of(),
+                kwargs
         ));
 
         MatchingConfigRequest request = new MatchingConfigRequest(
@@ -134,12 +153,24 @@ class AlgorithmControllerTest {
 
     @Test
     void testExportConfiguration() throws IOException, NoSuchFieldException, IllegalAccessException {
-        List<Pass> mockPasses = List.of(new Pass("pass1", "description", "0.1", "0.9",
-                Map.of("FIRST_NAME", true, "LAST_NAME", false), List.of()));
+        Kwargs kwargs = new Kwargs("JaroWinkler",
+                Map.of("FIRST_NAME", 0.9, "LAST_NAME", 0.95),
+                12.2,
+                Map.of("FIRST_NAME", 6.85, "LAST_NAME", 6.35));
+
+        List<Pass> mockPasses = List.of(new Pass(
+                "pass1",
+                "description",
+                "0.1",
+                "0.9",
+                Map.of("FIRST_NAME", true, "LAST_NAME", false),
+                List.of(),
+                kwargs
+        ));
 
         when(algorithmService.getMatchingConfiguration()).thenReturn(mockPasses);
 
-        String expectedJson = "[{\"name\":\"pass1\",\"description\":\"description\",\"lowerBound\":\"0.1\",\"upperBound\":\"0.9\",\"blockingCriteria\":{\"FIRST_NAME\":true,\"LAST_NAME\":false},\"matchingCriteria\":[]}]";
+        String expectedJson = objectMapper.writeValueAsString(mockPasses);
         ObjectMapper mockObjectMapper = mock(ObjectMapper.class);
         doReturn(expectedJson).when(mockObjectMapper).writeValueAsString(mockPasses);
 
@@ -157,10 +188,8 @@ class AlgorithmControllerTest {
         verify(mockObjectMapper).writeValueAsString(mockPasses);
     }
 
-
     @Test
     void testImportConfiguration() throws Exception {
-        // Prepare data
         MatchingConfigRequest mockConfigRequest = new MatchingConfigRequest(
                 "Test Label",
                 "Test Description",

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmServiceTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmServiceTest.java
@@ -93,8 +93,8 @@ class AlgorithmServiceTest {
         AlgorithmService spyAlgorithmService = spy(algorithmService);
 
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
-        Kwargs Kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
-        List<Pass> passes = List.of(new Pass("passName", "description", "0.2", "0.9", blockingCriteria, List.of(),Kwargs));
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
+        List<Pass> passes = List.of(new Pass("passName", "description", "0.2", "0.9", blockingCriteria, List.of(), kwargs));
 
         MatchingConfigRequest configRequest = new MatchingConfigRequest("testLabel", "testDescription", true, true, passes);
 

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmServiceTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmServiceTest.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.deduplication.algorithm;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cdc.nbs.deduplication.algorithm.dto.Kwargs;
 import gov.cdc.nbs.deduplication.algorithm.dto.Pass;
 import gov.cdc.nbs.deduplication.algorithm.mapper.AlgorithmConfigMapper;
 import gov.cdc.nbs.deduplication.algorithm.model.AlgorithmUpdateRequest;
@@ -75,7 +76,8 @@ class AlgorithmServiceTest {
     @Test
     void testConfigureMatching() {
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
-        List<Pass> passes = List.of(new Pass("TestPass", "Description", "0.1", "0.9", blockingCriteria, List.of()));
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
+        List<Pass> passes = List.of(new Pass("TestPass", "Description", "0.1", "0.9", blockingCriteria, List.of(), kwargs));
 
         MatchingConfigRequest request = new MatchingConfigRequest("testLabel", "testDescription", true, true, passes);
 
@@ -91,7 +93,8 @@ class AlgorithmServiceTest {
         AlgorithmService spyAlgorithmService = spy(algorithmService);
 
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
-        List<Pass> passes = List.of(new Pass("passName", "description", "0.2", "0.9", blockingCriteria, List.of()));
+        Kwargs Kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
+        List<Pass> passes = List.of(new Pass("passName", "description", "0.2", "0.9", blockingCriteria, List.of(),Kwargs));
 
         MatchingConfigRequest configRequest = new MatchingConfigRequest("testLabel", "testDescription", true, true, passes);
 
@@ -110,9 +113,10 @@ class AlgorithmServiceTest {
 
     @Test
     void testUpdateAlgorithm_withMissingBlockingCriteria() {
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
         MatchingConfigRequest configRequest = new MatchingConfigRequest(
                 "testLabel", "testDescription", true, true,
-                List.of(new Pass("passName", "description", "0.2", "0.9", null, List.of()))
+                List.of(new Pass("passName", "description", "0.2", "0.9", null, List.of(), kwargs))
         );
 
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
@@ -135,8 +139,9 @@ class AlgorithmServiceTest {
 
     @Test
     void testUpdateAlgorithmJsonProcessingException() throws Exception {
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
-        Pass pass = new Pass("TestPass", "Description", "0.1", "0.9", blockingCriteria, List.of());
+        Pass pass = new Pass("TestPass", "Description", "0.1", "0.9", blockingCriteria, List.of(), kwargs);
 
         MatchingConfigRequest request = new MatchingConfigRequest("Test Label", "Test Description", true, true, List.of(pass));
 
@@ -148,7 +153,8 @@ class AlgorithmServiceTest {
     @Test
     void testUpdateAlgorithm_withInvalidBounds() {
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true);
-        List<Pass> passes = List.of(new Pass("passName", "description", "invalid", "invalid", blockingCriteria, List.of()));
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
+        List<Pass> passes = List.of(new Pass("passName", "description", "invalid", "invalid", blockingCriteria, List.of(), kwargs));
 
         MatchingConfigRequest configRequest = new MatchingConfigRequest("Test Label", "Test Description", true, true, passes);
 

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/dto/KwargsTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/dto/KwargsTest.java
@@ -1,0 +1,18 @@
+package gov.cdc.nbs.deduplication.algorithm.dto;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class KwargsTest {
+
+    @Test
+    public void testKwargs() {
+        Kwargs kwargs = new Kwargs("JaroWinkler", Map.of("LAST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
+        assertNotNull(kwargs);
+        assertEquals("JaroWinkler",kwargs.similarityMeasure());
+    }
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/dto/PassTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/dto/PassTest.java
@@ -22,9 +22,23 @@ class PassTest {
                 new Method("exact", "Exact Match")
         );
 
+        // Define thresholds and log odds for Kwargs
+        Map<String, Double> thresholds = Map.of(
+                "FIRST_NAME", 0.9,
+                "LAST_NAME", 0.95
+        );
+
+        Map<String, Double> logOdds = Map.of(
+                "FIRST_NAME", 6.85,
+                "LAST_NAME", 6.35
+        );
+
+        // Create a Kwargs object
+        Kwargs kwargs = new Kwargs("JaroWinkler", thresholds, 12.2, logOdds);
+
         // Create Pass object with updated structure
         Pass pass = new Pass("Test Name", "Test Description", "0.1", "0.9",
-                blockingCriteria, List.of(matchingCriteria));
+                blockingCriteria, List.of(matchingCriteria), kwargs);
 
         // Validate basic properties
         assertEquals("Test Name", pass.name());
@@ -43,5 +57,20 @@ class PassTest {
         assertEquals("Last name", pass.matchingCriteria().get(0).field().name());
         assertEquals("exact", pass.matchingCriteria().get(0).method().value());
         assertEquals("Exact Match", pass.matchingCriteria().get(0).method().name());
+
+        // Validate Kwargs object
+        assertNotNull(pass.kwargs());
+        assertEquals("JaroWinkler", pass.kwargs().similarityMeasure());
+        assertEquals(12.2, pass.kwargs().trueMatchThreshold());
+
+        // Validate thresholds inside Kwargs
+        assertNotNull(pass.kwargs().thresholds());
+        assertEquals(0.9, pass.kwargs().thresholds().get("FIRST_NAME"));
+        assertEquals(0.95, pass.kwargs().thresholds().get("LAST_NAME"));
+
+        // Validate log odds inside Kwargs
+        assertNotNull(pass.kwargs().logOdds());
+        assertEquals(6.85, pass.kwargs().logOdds().get("FIRST_NAME"));
+        assertEquals(6.35, pass.kwargs().logOdds().get("LAST_NAME"));
     }
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/mapper/AlgorithmConfigMapperTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/mapper/AlgorithmConfigMapperTest.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.deduplication.algorithm.mapper;
 
 import gov.cdc.nbs.deduplication.algorithm.dto.AlgorithmPass;
 import gov.cdc.nbs.deduplication.algorithm.dto.Evaluator;
+import gov.cdc.nbs.deduplication.algorithm.dto.Kwargs;
 import gov.cdc.nbs.deduplication.algorithm.dto.MatchingCriteria;
 import gov.cdc.nbs.deduplication.algorithm.model.AlgorithmUpdateRequest;
 import gov.cdc.nbs.deduplication.algorithm.model.MatchingConfigRequest;
@@ -10,7 +11,10 @@ import org.junit.jupiter.api.Test;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import java.util.Map;
 
+import static gov.cdc.nbs.deduplication.algorithm.mapper.AlgorithmConfigMapper.castToMap;
+import static gov.cdc.nbs.deduplication.algorithm.mapper.AlgorithmConfigMapper.mapKwargs;
 import static org.junit.jupiter.api.Assertions.*;
 
 class AlgorithmConfigMapperTest {
@@ -104,5 +108,86 @@ class AlgorithmConfigMapperTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    void testMapKwargs_NullInput() {
+        assertNull(mapKwargs(null), "Should return null when input is null");
+    }
+
+    @Test
+    void testMapKwargs_AlreadyKwargsInstance() {
+        Kwargs originalKwargs = new Kwargs("JaroWinkler", Map.of("LAST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35));
+        Kwargs result = mapKwargs(originalKwargs);
+
+        assertSame(originalKwargs, result, "Should return the same instance if input is already Kwargs");
+    }
+
+    @Test
+    void testMapKwargs_ValidMapInput() {
+        Map<String, Object> inputMap = Map.of(
+                "similarity_measure", "Levenshtein",
+                "thresholds", Map.of("FIRST_NAME", 0.5),
+                "true_match_threshold", 0.8,
+                "log_odds", Map.of("LAST_NAME", 1.2)
+        );
+
+        Kwargs result = mapKwargs(inputMap);
+
+        assertNotNull(result, "Kwargs object should not be null");
+        assertEquals("Levenshtein", result.similarityMeasure(), "Incorrect similarity measure");
+        assertEquals(0.5, result.thresholds().get("FIRST_NAME"), "Incorrect threshold value");
+        assertEquals(0.8, result.trueMatchThreshold(), "Incorrect true match threshold");
+        assertEquals(1.2, result.logOdds().get("LAST_NAME"), "Incorrect log odds value");
+    }
+
+    @Test
+    void testMapKwargs_InvalidTrueMatchThreshold() {
+        Map<String, Object> inputMap = Map.of(
+                "similarity_measure", "Levenshtein",
+                "thresholds", Map.of("FIRST_NAME", 0.5),
+                "true_match_threshold", "not-a-number",
+                "log_odds", Map.of("LAST_NAME", 1.2)
+        );
+
+        Kwargs result = mapKwargs(inputMap);
+
+        assertNotNull(result, "Kwargs object should not be null");
+        assertNull(result.trueMatchThreshold(), "True match threshold should be null for invalid input");
+    }
+
+    @Test
+    void testMapKwargs_EmptyMap() {
+        Map<String, Object> inputMap = Map.of();
+
+        Kwargs result = mapKwargs(inputMap);
+
+        assertNotNull(result, "Kwargs object should not be null");
+        assertNull(result.similarityMeasure(), "Similarity measure should be null for an empty map");
+        assertNull(result.thresholds(), "Thresholds should be null for an empty map");
+        assertNull(result.trueMatchThreshold(), "True match threshold should be null for an empty map");
+        assertNull(result.logOdds(), "Log odds should be null for an empty map");
+    }
+
+    @Test
+    void testCastToMap_ValidMap() {
+        Map<String, Double> validMap = Map.of("FIRST_NAME", 0.7);
+        Map<String, Double> result = castToMap(validMap);
+
+        assertNotNull(result, "Result should not be null for valid input");
+        assertEquals(0.7, result.get("FIRST_NAME"), "Incorrect map value");
+    }
+
+    @Test
+    void testCastToMap_InvalidInput() {
+        Object invalidInput = "Not a map";
+        Map<String, Double> result = castToMap(invalidInput);
+
+        assertNull(result, "Result should be null for non-map input");
+    }
+
+    @Test
+    void testCastToMap_NullInput() {
+        assertNull(castToMap(null), "Result should be null for null input");
     }
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/mapper/AlgorithmRequestMapperTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/mapper/AlgorithmRequestMapperTest.java
@@ -37,6 +37,7 @@ class AlgorithmRequestMapperTest {
                 "FIRST_NAME", true,
                 "LAST_NAME", false
         );
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
 
         // Creating a sample Pass with blocking criteria and matching criteria
         List<Pass> passes = List.of(new Pass(
@@ -48,7 +49,8 @@ class AlgorithmRequestMapperTest {
                 List.of(new MatchingCriteria(
                         new Field("LAST_NAME", "Last name"),
                         new Method("exact", "matcher")
-                ))
+                )),
+                kwargs
         ));
 
         // Creating a MatchingConfiguration with the new Pass structure

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/model/MatchingConfigRequestTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/model/MatchingConfigRequestTest.java
@@ -77,10 +77,9 @@ class MatchingConfigRequestTest {
         assertNotEquals(request1, request5);
     }
 
-    Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
-
     @Test
     void testEqualsWithNull() {
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
         MatchingConfigRequest request = new MatchingConfigRequest(
                 "Test Label", "Test Description", true, true,
                 List.of(new Pass("passName", "description", "0.1", "0.9", Map.of(), List.of(), kwargs))

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/model/MatchingConfigRequestTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/model/MatchingConfigRequestTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.algorithm.model;
 
+import gov.cdc.nbs.deduplication.algorithm.dto.Kwargs;
 import gov.cdc.nbs.deduplication.algorithm.dto.Pass;
 import org.junit.jupiter.api.Test;
 
@@ -14,12 +15,14 @@ class MatchingConfigRequestTest {
     void testEqualsAndHashCode() {
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
 
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
+
         MatchingConfigRequest request1 = new MatchingConfigRequest(
                 "Test Label",
                 "Test Description",
                 true,
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of()))
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs))
         );
 
         MatchingConfigRequest request2 = new MatchingConfigRequest(
@@ -27,7 +30,7 @@ class MatchingConfigRequestTest {
                 "Test Description",
                 true,
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of()))
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs))
         );
 
         assertEquals(request1, request2);
@@ -38,29 +41,31 @@ class MatchingConfigRequestTest {
     void testEqualsWithDifferentValues() {
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
 
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
+
         MatchingConfigRequest request1 = new MatchingConfigRequest(
                 "Test Label", "Test Description", true, true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of()))
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs))
         );
 
         // Different label
         MatchingConfigRequest request2 = new MatchingConfigRequest(
                 "Different Label", "Test Description", true, true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of()))
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs))
         );
         assertNotEquals(request1, request2);
 
         // Different isDefault value
         MatchingConfigRequest request3 = new MatchingConfigRequest(
                 "Test Label", "Test Description", false, true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of()))
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs))
         );
         assertNotEquals(request1, request3);
 
         // Different includeMultipleMatches value
         MatchingConfigRequest request4 = new MatchingConfigRequest(
                 "Test Label", "Test Description", true, false,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of()))
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs))
         );
         assertNotEquals(request1, request4);
 
@@ -72,11 +77,13 @@ class MatchingConfigRequestTest {
         assertNotEquals(request1, request5);
     }
 
+    Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
+
     @Test
     void testEqualsWithNull() {
         MatchingConfigRequest request = new MatchingConfigRequest(
                 "Test Label", "Test Description", true, true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", Map.of(), List.of()))
+                List.of(new Pass("passName", "description", "0.1", "0.9", Map.of(), List.of(), kwargs))
         );
 
         assertNotEquals(null, request);
@@ -85,10 +92,11 @@ class MatchingConfigRequestTest {
     @Test
     void testToString() {
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
 
         MatchingConfigRequest request = new MatchingConfigRequest(
                 "Test Label", "Test Description", true, true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of()))
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs))
         );
 
         String actualString = request.toString();
@@ -106,9 +114,11 @@ class MatchingConfigRequestTest {
     void testConstructorAndGetters() {
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
 
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
+
         MatchingConfigRequest request = new MatchingConfigRequest(
                 "Test Label", "Test Description", true, false,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of()))
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs))
         );
 
         assertEquals("Test Label", request.label());

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/model/MatchingConfigurationTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/model/MatchingConfigurationTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.algorithm.model;
 
+import gov.cdc.nbs.deduplication.algorithm.dto.Kwargs;
 import gov.cdc.nbs.deduplication.algorithm.dto.Pass;
 import org.junit.jupiter.api.Test;
 
@@ -13,13 +14,13 @@ class MatchingConfigurationTest {
     @Test
     void testEqualsAndHashCode() {
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
-
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
         MatchingConfiguration config1 = new MatchingConfiguration(
                 1L,
                 "Test Label",
                 "Test Description",
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of())),
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs)),
                 new Double[]{0.0, 1.0}
         );
 
@@ -28,7 +29,7 @@ class MatchingConfigurationTest {
                 "Test Label",
                 "Test Description",
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of())),
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs)),
                 new Double[]{0.0, 1.0}
         );
 
@@ -39,13 +40,13 @@ class MatchingConfigurationTest {
     @Test
     void testEqualsWithDifferentValues() {
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
-
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
         MatchingConfiguration config1 = new MatchingConfiguration(
                 1L,
                 "Test Label",
                 "Test Description",
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of())),
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs)),
                 new Double[]{0.0, 1.0}
         );
 
@@ -54,7 +55,7 @@ class MatchingConfigurationTest {
                 "Different Label",  // Different label
                 "Test Description",
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of())),
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs)),
                 new Double[]{0.0, 1.0}
         );
         assertNotEquals(config1, config2);
@@ -64,7 +65,7 @@ class MatchingConfigurationTest {
                 "Test Label",
                 "Test Description",
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of())),
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs)),
                 new Double[]{0.0, 1.0}
         );
         assertNotEquals(config1, config3);
@@ -74,7 +75,7 @@ class MatchingConfigurationTest {
                 "Test Label",
                 "Test Description",
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of())),
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs)),
                 new Double[]{0.1, 0.9}  // Different belongingnessRatio
         );
         assertNotEquals(config1, config4);
@@ -97,13 +98,13 @@ class MatchingConfigurationTest {
     @Test
     void testToString() {
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
-
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
         MatchingConfiguration config = new MatchingConfiguration(
                 1L,
                 "Test Label",
                 "Test Description",
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of())),
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs)),
                 new Double[]{0.0, 1.0}
         );
 
@@ -121,13 +122,13 @@ class MatchingConfigurationTest {
     @Test
     void testConstructorAndGetters() {
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
-
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
         MatchingConfiguration config = new MatchingConfiguration(
                 1L,
                 "Test Label",
                 "Test Description",
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of())),
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs)),
                 new Double[]{0.0, 1.0}
         );
 
@@ -143,13 +144,13 @@ class MatchingConfigurationTest {
     @Test
     void testEqualsWithNullBelongingnessRatio() {
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
-
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
         MatchingConfiguration config1 = new MatchingConfiguration(
                 1L,
                 "Test Label",
                 "Test Description",
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of())),
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs)),
                 null  // belongingnessRatio is null
         );
 
@@ -158,7 +159,7 @@ class MatchingConfigurationTest {
                 "Test Label",
                 "Test Description",
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of())),
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs)),
                 null  // belongingnessRatio is also null
         );
 
@@ -169,7 +170,7 @@ class MatchingConfigurationTest {
                 "Test Label",
                 "Test Description",
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of())),
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs)),
                 new Double[]{0.0, 1.0}
         );
 
@@ -180,12 +181,14 @@ class MatchingConfigurationTest {
     void testEqualsWithIdenticalObjects() {
         Map<String, Boolean> blockingCriteria = Map.of("FIRST_NAME", true, "LAST_NAME", false);
 
+        Kwargs kwargs = new Kwargs("JaroWinkler",Map.of("FIRST_NAME", 0.35), 12.2, Map.of("LAST_NAME", 0.35) );
+
         MatchingConfiguration config = new MatchingConfiguration(
                 1L,
                 "Test Label",
                 "Test Description",
                 true,
-                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of())),
+                List.of(new Pass("passName", "description", "0.1", "0.9", blockingCriteria, List.of(), kwargs)),
                 new Double[]{0.0, 1.0}
         );
 


### PR DESCRIPTION
## Notes

As a user, I want the 'Export/Import Configuration' feature to include data elements so that when I export a configuration, all relevant data elements are included, and when I import a configuration, the data elements are restored along with the pass configuration.

1. The existing API must be updated to support exporting and importing data elements along with the pass configuration.
2. The exported data elements should also contain the odds ratio and the threshold.
3. The export file format should be application/json.

Export API response:
<img width="1084" alt="image" src="https://github.com/user-attachments/assets/a6397dc0-0da4-4558-ad3f-cfc2cf4c539d" />

Import API body and Response:
<img width="1090" alt="image" src="https://github.com/user-attachments/assets/81fa7cae-222a-4b2e-aef8-7ccac226525d" />


## JIRA

- **Related story**: [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CND-227?atlOrigin=eyJpIjoiNWRiN2Y5YTg3MWM5NGFlYTg3MTUxZDEzNjViMDUxYzciLCJwIjoiaiJ9)

## Checklist

- [x] PR focuses on a single story.
- [x] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?