### PR TITLE
Update base path to /nbs/api/deduplication. Remove /api from controllers

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/AlgorithmController.java
@@ -24,7 +24,7 @@ import gov.cdc.nbs.deduplication.algorithm.pass.exception.AlgorithmException;
 import gov.cdc.nbs.deduplication.algorithm.pass.model.ui.Algorithm;
 
 @RestController
-@RequestMapping("/api/configuration")
+@RequestMapping("/configuration")
 public class AlgorithmController {
 
     private final PassService passService;

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/dataelements/DataElementsController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/dataelements/DataElementsController.java
@@ -10,7 +10,7 @@ import gov.cdc.nbs.deduplication.algorithm.dataelements.model.DataElements;
 import gov.cdc.nbs.deduplication.algorithm.pass.PassService;
 
 @RestController
-@RequestMapping("/api/configuration/data-elements")
+@RequestMapping("/configuration/data-elements")
 public class DataElementsController {
 
     private final DataElementsService service;

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/pass/PassController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/pass/PassController.java
@@ -12,7 +12,7 @@ import gov.cdc.nbs.deduplication.algorithm.pass.model.ui.Algorithm;
 import gov.cdc.nbs.deduplication.algorithm.pass.model.ui.Algorithm.Pass;
 
 @RestController
-@RequestMapping("/api/configuration/pass")
+@RequestMapping("/configuration/pass")
 public class PassController {
 
     private final PassService passService;

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/controller/MergeGroupController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/controller/MergeGroupController.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 
 @RestController
-@RequestMapping("/api/deduplication")
+@RequestMapping("/deduplication")
 public class MergeGroupController {
 
   private final MergeGroupHandler mergeGroupHandler;

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/controller/TestController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/duplicates/controller/TestController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/batch-job/test")
+@RequestMapping("/batch-job/test")
 public class TestController {
 
   private final JobLauncher jobLauncher;

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/matching/MatchController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/matching/MatchController.java
@@ -7,7 +7,7 @@ import gov.cdc.nbs.deduplication.matching.model.PersonMatchRequest;
 import gov.cdc.nbs.deduplication.matching.model.RelateRequest;
 
 @RestController
-@RequestMapping("/api/deduplication")
+@RequestMapping("/deduplication")
 public class MatchController {
 
   private final MatchService matchService;

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/SeedController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/seed/SeedController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/deduplication/seed")
+@RequestMapping("/deduplication/seed")
 public class SeedController {
 
   private final JobLauncher launcher;

--- a/deduplication/src/main/resources/application.yaml
+++ b/deduplication/src/main/resources/application.yaml
@@ -1,7 +1,7 @@
 server:
   port: 8083
   servlet:
-    context-path: /nbs/deduplication
+    context-path: /nbs/api/deduplication
 
 spring:
   application.name: deduplication

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/controller/MergeGroupControllerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/duplicates/controller/MergeGroupControllerTest.java
@@ -44,7 +44,7 @@ class MergeGroupControllerTest {
 
 
     // Act & Assert
-    mockMvc.perform(get("/api/deduplication/merge-groups")
+    mockMvc.perform(get("/deduplication/merge-groups")
             .param("page", String.valueOf(page))
             .param("size", String.valueOf(size)))
         .andExpect(status().isOk())
@@ -56,7 +56,7 @@ class MergeGroupControllerTest {
     MergeStatusRequest request = new MergeStatusRequest(100L, false);
 
     // Act & Assert
-    mockMvc.perform(post("/api/deduplication/merge-status")
+    mockMvc.perform(post("/deduplication/merge-status")
             .contentType("application/json")
             .content("{\"personUid\": 100, \"status\": \"false\"}"))
         .andExpect(status().isOk())
@@ -72,7 +72,7 @@ class MergeGroupControllerTest {
     doThrow(new RuntimeException("Some error")).when(mergeGroupHandler).updateMergeStatus(request);
 
     // Act & Assert
-    mockMvc.perform(post("/api/deduplication/merge-status")
+    mockMvc.perform(post("/deduplication/merge-status")
             .contentType("application/json")
             .content("{\"personUid\": 100, \"status\": \"false\"}"))
         .andExpect(status().isInternalServerError())


### PR DESCRIPTION
## Notes

Updates the base path for the deduplication service to prevent conflict in a deployed environment.

New deduplication base: `/nbs/api/deduplication`

## JIRA

- **Related story**: [CND-234](https://cdc-nbs.atlassian.net/browse/CND-234)

## Checklist

- [x] PR focuses on a single story.
- [x] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [x] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [x] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?

[CND-234]: https://cdc-nbs.atlassian.net/browse/CND-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ