### PR TITLE
Add health endpoint. Remove unnecessary semicolon

### DIFF
--- a/containers/db/initialize/restore.d/04-create-deduplication-db.sql
+++ b/containers/db/initialize/restore.d/04-create-deduplication-db.sql
@@ -36,6 +36,6 @@ CREATE TABLE match_candidates (
   person_uid bigint,
   mpi_person_id uniqueidentifier,
   date_identified DATETIME DEFAULT GETDATE(),
-  is_merge BIT NULL;
+  is_merge BIT NULL
 );
 GO

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/health/HealthController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/health/HealthController.java
@@ -1,0 +1,13 @@
+package gov.cdc.nbs.deduplication.health;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+  @GetMapping("/health")
+  public HealthResponse health() {
+    return new HealthResponse("UP");
+  }
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/health/HealthResponse.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/health/HealthResponse.java
@@ -1,0 +1,5 @@
+package gov.cdc.nbs.deduplication.health;
+
+public record HealthResponse(String status) {
+
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/health/HealthControllerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/health/HealthControllerTest.java
@@ -1,0 +1,16 @@
+package gov.cdc.nbs.deduplication.health;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HealthControllerTest {
+
+  HealthController controller = new HealthController();
+
+  @Test
+  void should_return_health() {
+    HealthResponse response = controller.health();
+
+    assertThat(response.status()).isEqualTo("UP");
+  }
+}


### PR DESCRIPTION
## Notes

Adds a `/health` endpoint for deduplication API.
Removes extra `;` from init script