### PR TITLE
Cnd 285 ethnicity

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/batch/mapper/PersonMergeDataMapper.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/batch/mapper/PersonMergeDataMapper.java
@@ -3,7 +3,12 @@ package gov.cdc.nbs.deduplication.batch.mapper;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.lang.NonNull;
@@ -14,7 +19,17 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import gov.cdc.nbs.deduplication.batch.model.PersonMergeData;
-import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.*;
+import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.Address;
+import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.AdminComments;
+import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.Ethnicity;
+import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.GeneralPatientInformation;
+import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.Identification;
+import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.Investigation;
+import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.Mortality;
+import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.Name;
+import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.PhoneEmail;
+import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.Race;
+import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.SexAndBirth;
 
 public class PersonMergeDataMapper implements RowMapper<PersonMergeData> {
 
@@ -28,7 +43,7 @@ public class PersonMergeDataMapper implements RowMapper<PersonMergeData> {
     AdminComments adminComments = mapAdminComments(rs);
 
     // Ethnicity Mapping
-    Ethnicity ethnicity = mapEthnicity(rs);
+    Ethnicity ethnicity = mapEthnicity(rs.getString("ethnicity"));
 
     // Sex & Birth Mapping
     SexAndBirth sexAndBirth = mapSexAndBirth(rs);
@@ -83,17 +98,15 @@ public class PersonMergeDataMapper implements RowMapper<PersonMergeData> {
         rs.getString("admin_comments"));
   }
 
-  // ETHNICITY Mapping
-  Ethnicity mapEthnicity(ResultSet rs) throws SQLException {
-    String asOfDate = String.valueOf(rs.getString("as_of_date_ethnicity"));
-    String ethnicGroupDescription = String.valueOf(rs.getString("ethnic_group_desc_txt"));
-    String spanishOrigin = String.valueOf(rs.getString("spanish_origin"));
-    String ethnicUnknownReason = String.valueOf(rs.getString("ethnic_unknown_reason"));
-    return new Ethnicity(
-        asOfDate,
-        ethnicGroupDescription,
-        spanishOrigin,
-        ethnicUnknownReason);
+  Ethnicity mapEthnicity(String ethnicityString) {
+    if (ethnicityString == null) {
+      return new Ethnicity();
+    }
+    try {
+      return mapper.readValue(ethnicityString, Ethnicity.class);
+    } catch (JsonProcessingException e) {
+      throw new PersonMapException("Failed to parse patient ethnicity");
+    }
   }
 
   // SEX & BIRTH Mapping

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/batch/model/PersonMergeData.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/batch/model/PersonMergeData.java
@@ -21,12 +21,18 @@ public record PersonMergeData(
       String comment) {
   }
 
-  // ETHNICITY Object
   public record Ethnicity(
-      String asOfDate,
-      String ethnicGroupDescription,
-      String spanishOrigin,
-      String ethnicUnknownReason) {
+      String asOf,
+      String ethnicity,
+      String reasonUnknown,
+      String spanishOrigin) {
+    public Ethnicity() {
+      this(
+          null,
+          null,
+          null,
+          null);
+    }
   }
 
   // SEX & BIRTH Object

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/constants/QueryConstants.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/constants/QueryConstants.java
@@ -576,11 +576,6 @@ public class QueryConstants {
           p.person_parent_uid,
           p.as_of_date_admin AS comment_date,
           p.description AS admin_comments,
-          -- ETHNICITY
-          p.as_of_date_ethnicity,
-          p.ethnic_group_desc_txt,
-          cvg_ethnic_group.code_short_desc_txt AS spanish_origin,
-          ethnic_unknown.code_short_desc_txt AS ethnic_unknown_reason,
           -- SEX & BIRTH
           p.as_of_date_sex,
           p.birth_time,
@@ -618,6 +613,7 @@ public class QueryConstants {
           nested.name,
           nested.identifiers,
           nested.race,
+          nested.ethnicity,
           --INVESTIGATIONS
           (
               SELECT
@@ -770,6 +766,32 @@ public class QueryConstants {
                               FOR JSON PATH, INCLUDE_NULL_VALUES
                           ) AS race
                   ) AS race,
+                -- Ethnicity
+                  (
+                   SELECT
+                      (
+                      SELECT
+                        p.as_of_date_ethnicity AS asOf,
+                        cvg.code_desc_txt AS ethnicity,
+                        p.ethnic_unk_reason_cd AS reasonUnknown,
+                        STRING_AGG(cvg2.code_desc_txt, ' | ') AS spanishOrigin
+                      FROM
+                        Person_ethnic_group eg
+                        JOIN nbs_srte..code_value_general cvg ON cvg.code = p.ethnic_group_ind
+                        AND cvg.code_set_nm = 'PHVS_ETHNICITYGROUP_CDC_UNK'
+                        JOIN nbs_srte..code_value_general cvg2 ON cvg2.code = eg.ethnic_group_cd
+                        AND cvg2.code_set_nm = 'P_ETHN'
+                      WHERE
+                        eg.person_uid = p.person_uid
+                      GROUP BY
+                        eg.person_uid,
+                        cvg.code_desc_txt
+                      FOR JSON
+                        PATH,
+                        INCLUDE_NULL_VALUES,
+                        WITHOUT_ARRAY_WRAPPER
+                    ) AS ethnicity
+                ) AS ethnicity,
                   -- person phone
                   (
                       SELECT
@@ -823,7 +845,6 @@ public class QueryConstants {
                                   STRING_ESCAPE(pn.last_nm2, 'json') AS secondLast,
                                   cvg3.code_short_desc_txt AS suffix,
                                   STRING_ESCAPE(pn.nm_degree, 'json') AS degree
-
                               FROM
                                   person_name pn WITH (NOLOCK)
                                   LEFT JOIN nbs_srte..code_value_general cvg ON pn.nm_use_cd = cvg.code AND cvg.code_set_nm = 'P_NM_USE'

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/constants/QueryConstants.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/constants/QueryConstants.java
@@ -770,22 +770,28 @@ public class QueryConstants {
                   (
                    SELECT
                       (
-                      SELECT
-                        p.as_of_date_ethnicity AS asOf,
-                        cvg.code_desc_txt AS ethnicity,
-                        p.ethnic_unk_reason_cd AS reasonUnknown,
-                        STRING_AGG(cvg2.code_desc_txt, ' | ') AS spanishOrigin
-                      FROM
-                        Person_ethnic_group eg
-                        JOIN nbs_srte..code_value_general cvg ON cvg.code = p.ethnic_group_ind
-                        AND cvg.code_set_nm = 'PHVS_ETHNICITYGROUP_CDC_UNK'
-                        JOIN nbs_srte..code_value_general cvg2 ON cvg2.code = eg.ethnic_group_cd
-                        AND cvg2.code_set_nm = 'P_ETHN'
-                      WHERE
-                        eg.person_uid = p.person_uid
-                      GROUP BY
-                        eg.person_uid,
-                        cvg.code_desc_txt
+                        SELECT
+                            ep.as_of_date_ethnicity AS asOf,
+                            cvg.code_desc_txt AS ethnicity,
+                            cvg3.code_short_desc_txt AS reasonUnknown,
+                            STRING_AGG(cvg2.code_desc_txt, ' | ') AS spanishOrigin
+                        FROM
+                            person ep
+                            LEFT JOIN Person_ethnic_group eg ON ep.person_uid = eg.person_uid
+                            LEFT JOIN nbs_srte..code_value_general cvg ON cvg.code = ep.ethnic_group_ind
+                            AND cvg.code_set_nm = 'PHVS_ETHNICITYGROUP_CDC_UNK'
+                            LEFT JOIN nbs_srte..code_value_general cvg2 ON cvg2.code = eg.ethnic_group_cd
+                            AND cvg2.code_set_nm = 'P_ETHN'
+                            LEFT JOIN nbs_srte..code_value_general cvg3 ON cvg3.code = ep.ethnic_unk_reason_cd
+                            AND cvg3.code_set_nm = 'P_ETHN_UNK_REASON'
+                        WHERE
+                            ep.person_uid = p.person_uid
+                        GROUP BY
+                            ep.person_uid,
+                            ep.as_of_date_ethnicity,
+                            ep.ethnic_unk_reason_cd,
+                            cvg.code_desc_txt,
+                            cvg3.code_short_desc_txt
                       FOR JSON
                         PATH,
                         INCLUDE_NULL_VALUES,

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/batch/mapper/PersonMergeDataMapperTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/batch/mapper/PersonMergeDataMapperTest.java
@@ -234,7 +234,7 @@ class PersonMergeDataMapperTest {
   }
 
   private void assertEthnicity(PersonMergeData personMergeData) {
-    assertThat(personMergeData.ethnicity().asOfDate()).isEqualTo(ETHNICITY_AS_OF_DATE);
+    assertThat(personMergeData.ethnicity().asOf()).isEqualTo(ETHNICITY_AS_OF_DATE);
     assertThat(personMergeData.ethnicity().ethnicGroupDescription()).isEqualTo(ETHNIC_GROUP_DESC_TXT);
     assertThat(personMergeData.ethnicity().spanishOrigin()).isEqualTo(SPANISH_ORIGIN);
     assertThat(personMergeData.ethnicity().ethnicUnknownReason()).isEqualTo(ETHNIC_UNKNOWN_REASON);

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/batch/mapper/PersonMergeDataMapperTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/batch/mapper/PersonMergeDataMapperTest.java
@@ -29,10 +29,9 @@ class PersonMergeDataMapperTest {
   private static final Timestamp COMMENT_DATE_TIMESTAMP = Timestamp.valueOf("2023-01-10 00:00:00");
   private static final String COMMENTS = "Admin comments here";
 
-  private static final String ETHNICITY_AS_OF_DATE = "2023-01-01";
+  private static final String ETHNICITY_AS_OF_DATE = "2025-05-30T00:00:00";
   private static final String ETHNIC_GROUP_DESC_TXT = "Hispanic or Latino";
-  private static final String SPANISH_ORIGIN = "Yes";
-  private static final String ETHNIC_UNKNOWN_REASON = "Unknown";
+  private static final String SPANISH_ORIGIN = "Central American | Cuban";
 
   private static final String SEX_AND_BIRTH_AS_OF_DATE = "2023-02-01";
   private static final String BIRTH_TIME = "1990-01-01T00:00:00Z";
@@ -137,13 +136,21 @@ class PersonMergeDataMapperTest {
       ]
       """;
 
+  private static final String ETHNICITY_STRING = """
+      {
+      "asOf": "2025-05-30T00:00:00",
+      "ethnicity": "Hispanic or Latino",
+      "reasonUnknown": null,
+      "spanishOrigin": "Central American | Cuban"
+      }
+      """;
+
   @Test
   void testMapRow() throws Exception {
     ResultSet rs = Mockito.mock(ResultSet.class);
     // Mocking
     when(rs.getString("person_parent_uid")).thenReturn(PERSON_UID);
     mockGeneralFields(rs);
-    mockEthnicityFields(rs);
     mockSexAndBirthFields(rs);
     mockMortalityFields(rs);
     mockGeneralPatientInformationFields(rs);
@@ -168,13 +175,6 @@ class PersonMergeDataMapperTest {
   private void mockGeneralFields(ResultSet rs) throws SQLException {
     when(rs.getTimestamp("comment_date")).thenReturn(COMMENT_DATE_TIMESTAMP);
     when(rs.getString("admin_comments")).thenReturn(COMMENTS);
-  }
-
-  private void mockEthnicityFields(ResultSet rs) throws SQLException {
-    when(rs.getString("as_of_date_ethnicity")).thenReturn(ETHNICITY_AS_OF_DATE);
-    when(rs.getString("ethnic_group_desc_txt")).thenReturn(ETHNIC_GROUP_DESC_TXT);
-    when(rs.getString("spanish_origin")).thenReturn(SPANISH_ORIGIN);
-    when(rs.getString("ethnic_unknown_reason")).thenReturn(ETHNIC_UNKNOWN_REASON);
   }
 
   private void mockSexAndBirthFields(ResultSet rs) throws SQLException {
@@ -225,6 +225,7 @@ class PersonMergeDataMapperTest {
     when(rs.getString("name")).thenReturn(NAME_STRING);
     when(rs.getString("identifiers")).thenReturn(IDENTIFIER_STRING);
     when(rs.getString("race")).thenReturn(RACE_STRING);
+    when(rs.getString("ethnicity")).thenReturn(ETHNICITY_STRING);
   }
 
   // Assertion Methods
@@ -235,9 +236,9 @@ class PersonMergeDataMapperTest {
 
   private void assertEthnicity(PersonMergeData personMergeData) {
     assertThat(personMergeData.ethnicity().asOf()).isEqualTo(ETHNICITY_AS_OF_DATE);
-    assertThat(personMergeData.ethnicity().ethnicGroupDescription()).isEqualTo(ETHNIC_GROUP_DESC_TXT);
+    assertThat(personMergeData.ethnicity().ethnicity()).isEqualTo(ETHNIC_GROUP_DESC_TXT);
     assertThat(personMergeData.ethnicity().spanishOrigin()).isEqualTo(SPANISH_ORIGIN);
-    assertThat(personMergeData.ethnicity().ethnicUnknownReason()).isEqualTo(ETHNIC_UNKNOWN_REASON);
+    assertThat(personMergeData.ethnicity().reasonUnknown()).isNull();
   }
 
   private void assertSexAndBirth(PersonMergeData personMergeData) {

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/batch/mapper/PersonMergeDataMapperTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/batch/mapper/PersonMergeDataMapperTest.java
@@ -5,6 +5,7 @@ import org.mockito.Mockito;
 
 import gov.cdc.nbs.deduplication.batch.model.PersonMergeData;
 import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.Address;
+import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.Ethnicity;
 import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.Identification;
 import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.Name;
 import gov.cdc.nbs.deduplication.batch.model.PersonMergeData.PhoneEmail;
@@ -382,6 +383,23 @@ class PersonMergeDataMapperTest {
     String raceString = "asdf";
     PersonMapException ex = assertThrows(PersonMapException.class, () -> mapper.mapRaces(raceString));
     assertThat(ex.getMessage()).isEqualTo("Failed to parse patient race");
+  }
+
+  @Test
+  void testMapEthnicityEmpty() {
+    String ethnicityString = null;
+    Ethnicity ethnicity = mapper.mapEthnicity(ethnicityString);
+    assertThat(ethnicity.asOf()).isNull();
+    assertThat(ethnicity.ethnicity()).isNull();
+    assertThat(ethnicity.reasonUnknown()).isNull();
+    assertThat(ethnicity.spanishOrigin()).isNull();
+  }
+
+  @Test
+  void testMapEthnicityException() {
+    String ethnicityString = "asdf";
+    PersonMapException ex = assertThrows(PersonMapException.class, () -> mapper.mapEthnicity(ethnicityString));
+    assertThat(ex.getMessage()).isEqualTo("Failed to parse patient ethnicity");
   }
 
   @Test

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/PatientMergeControllerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/PatientMergeControllerTest.java
@@ -225,8 +225,8 @@ class PatientMergeControllerTest {
             new PersonMergeData.Ethnicity( // Ethnicity
                 "2023-01-01",
                 "Hispanic or Latino",
-                "Yes",
-                "Unknown"),
+                "Unknown reason",
+                "Cuban"),
             new PersonMergeData.SexAndBirth( // Sex & Birth
                 "2023-02-01",
                 "1990-01-01T00:00:00Z",
@@ -276,10 +276,10 @@ class PatientMergeControllerTest {
             "personUid": "1",
             "adminComments": {"date": "2023-01-01", "comment":  "test comment"},
             "ethnicity": {
-              "asOfDate": "2023-01-01",
-              "ethnicGroupDescription": "Hispanic or Latino",
-              "spanishOrigin": "Yes",
-              "ethnicUnknownReason": "Unknown"
+              "asOf": "2023-01-01",
+              "ethnicity": "Hispanic or Latino",
+              "spanishOrigin": "Cuban",
+              "reasonUnknown": "Unknown reason"
             },
             "sexAndBirth": {
               "asOfDate": "2023-02-01",


### PR DESCRIPTION
## Notes

1. Allows Ethnicity fields to directly map to record.
2. Updates Ethnicity `spanishOrigin` to aggregate the values: `Central American | Cuban` to match new design

## JIRA

- **Related story**: [CND-285](https://cdc-nbs.atlassian.net/browse/CND-285)

## Checklist

- [x] PR focuses on a single story.
- [x] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [x] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?