### PR TITLE
[CNDE-2847] HOTFIX- Code value fix for question identifier

### DIFF
--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/nbs/ecr/service/helper/CdaCaseMappingHelper.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/nbs/ecr/service/helper/CdaCaseMappingHelper.java
@@ -347,8 +347,9 @@ public class CdaCaseMappingHelper implements ICdaCaseMappingHelper {
         if(output.getCode() == null) {
             output.addNewCode();
         }
-        output.getCode().setCode(questionLookUpDto.getQuesCodeSystemCd());
-        output.getCode().setCodeSystem(questionLookUpDto.getQuesCodeSystemDescTxt());
+        output.getCode().setCode(questionId);
+        output.getCode().setCodeSystem(questionLookUpDto.getQuesCodeSystemCd());
+        output.getCode().setCodeSystemName(questionLookUpDto.getQuesCodeSystemDescTxt());
         output.getCode().setDisplayName(questionLookUpDto.getQuesDisplayName());
 
         for(int i = 0; i < repeats.size(); i++) {

--- a/data-ingestion-service/src/main/java/gov/cdc/dataingestion/nbs/ecr/service/helper/CdaMapHelper.java
+++ b/data-ingestion-service/src/main/java/gov/cdc/dataingestion/nbs/ecr/service/helper/CdaMapHelper.java
@@ -557,10 +557,10 @@ public class CdaMapHelper implements ICdaMapHelper {
                 if (result.getQuesCodeSystemCd() != null && !result.getQuesCodeSystemCd().isEmpty()) {
                     dto.setQuesCodeSystemCd(result.getQuesCodeSystemCd());
                 }
-                else if (result.getQuesCodeSystemDescTxt() != null && !result.getQuesCodeSystemDescTxt().isEmpty()) {
+                if (result.getQuesCodeSystemDescTxt() != null && !result.getQuesCodeSystemDescTxt().isEmpty()) {
                     dto.setQuesCodeSystemDescTxt(result.getQuesCodeSystemDescTxt());
                 }
-                else if (result.getQuesDisplayName() != null && !result.getQuesDisplayName().isEmpty()) {
+                if (result.getQuesDisplayName() != null && !result.getQuesDisplayName().isEmpty()) {
                     dto.setQuesDisplayName(result.getQuesDisplayName());
                 }
             }


### PR DESCRIPTION
## Notes

This PR contains the fix for the question identifier code value fix in the ECR's CDA mapper.

## JIRA

- **Related story**: [Jira Ticket](https://cdc-nbs.atlassian.net/browse/CNDE-2847)

## Checklist

- [x] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [x] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [x] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [x] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [x] Does the `gradle build` pass in your local? 
- [x] Is the `gradle build` logs attached?

```
> Task :data-ingestion-service:test
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│data-ingestion-service:test results: SUCCESS (282 tests, 282 successes, 0 failures, 0 skipped) in 1 minutes, 9.560 seconds                                             │
│Report file: /Users/ragulshanmugam/Documents/Workspace/NEDSS-DataIngestion/NEDSS-DataIngestion/data-ingestion-service/build/reports/tests/test/index.html              │
│Cucumber report: /Users/ragulshanmugam/Documents/Workspace/NEDSS-DataIngestion/NEDSS-DataIngestion/data-ingestion-service/build/reports/tests/test/cucumber-report.html│
│Jacoco report: /Users/ragulshanmugam/Documents/Workspace/NEDSS-DataIngestion/NEDSS-DataIngestion/data-ingestion-service/build/reports/jacoco/test/html/index.html      │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
TEST FINISHED

```