### PR TITLE
Implement merging of selected person names

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandler.java
@@ -1,0 +1,118 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+@Order(3)
+public class PersonNamesMergeHandler implements SectionMergeHandler {
+
+  private final NamedParameterJdbcTemplate nbsTemplate;
+
+  static final String UPDATE_ALL_NAMES_INACTIVE = """
+      UPDATE person_name
+      SET record_status_cd = 'INACTIVE',
+          last_chg_time = GETDATE()
+      WHERE person_uid = :personUid
+      """;
+
+  static final String UPDATE_SELECTED_EXCLUDED_NAMES_INACTIVE = """
+      UPDATE person_name
+      SET record_status_cd = 'INACTIVE',
+          last_chg_time = GETDATE()
+      WHERE person_uid = :personUid
+        AND person_name_seq NOT IN (:sequences)
+      """;
+
+  static final String FIND_MAX_SEQUENCE_PERSON_NAME = """
+      SELECT MAX(person_name_seq)
+      FROM person_name
+      WHERE person_uid = :personUid
+      """;
+
+  static final String UPDATE_SUPERSEDED_NAME_TO_SURVIVING = """
+      UPDATE person_name
+      SET person_uid = :survivingId,
+          person_name_seq = :newSeq,
+          last_chg_time = GETDATE()
+      WHERE person_uid = :superseded
+      AND person_name_seq = :oldSeq
+      """;
+
+  public PersonNamesMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
+    this.nbsTemplate = nbsTemplate;
+  }
+
+  //Merge modifications have been applied to the person names
+  @Override
+  public void handleMerge(String matchId, PatientMergeRequest request) {
+    mergePersonNames(request.survivingRecord(), request.names());
+  }
+
+  private void mergePersonNames(String survivorId, List<PatientMergeRequest.NameId> names) {
+    List<Integer> survivingNamesSequences = new ArrayList<>();
+    Map<String, List<Integer>> supersededNames = new HashMap<>();
+    categorizeNames(survivorId, names, survivingNamesSequences, supersededNames);
+    markUnselectedNamesInactive(survivorId, survivingNamesSequences);
+    updateSupersededNames(survivorId, supersededNames);
+  }
+
+  //split the selected names into surviving names and superseded names
+  private void categorizeNames(String survivorId, List<PatientMergeRequest.NameId> names,
+      List<Integer> survivingSequences, Map<String, List<Integer>> supersededNames) {
+
+    for (PatientMergeRequest.NameId name : names) {
+      String personUid = name.personUid();
+      Integer seq = Integer.parseInt(name.sequence());
+
+      if (personUid.equals(survivorId)) {
+        survivingSequences.add(seq);
+      } else {
+        supersededNames.computeIfAbsent(personUid, k -> new ArrayList<>()).add(seq);
+      }
+    }
+  }
+
+
+  private void markUnselectedNamesInactive(String survivorId, List<Integer> selectedSequences) {
+    String query = selectedSequences.isEmpty() ? UPDATE_ALL_NAMES_INACTIVE : UPDATE_SELECTED_EXCLUDED_NAMES_INACTIVE;
+    Map<String, Object> params = new HashMap<>();
+    params.put("personUid", survivorId);
+    if (!selectedSequences.isEmpty()) {
+      params.put("sequences", selectedSequences);
+    }
+    nbsTemplate.update(query, params);
+  }
+
+  private void updateSupersededNames(String survivorId, Map<String, List<Integer>> supersededNames) {
+    for (Map.Entry<String, List<Integer>> entry : supersededNames.entrySet()) {
+      moveSupersededNamesToSurviving(entry.getKey(), entry.getValue(), survivorId);
+    }
+  }
+
+  private void moveSupersededNamesToSurviving(String superseded, List<Integer> sequences, String survivingId) {
+    int survivingMaxSeq = getMaxSequenceForPerson(survivingId);
+
+    for (Integer seq : sequences) {
+      int newSeq = ++survivingMaxSeq;
+      Map<String, Object> params = new HashMap<>();
+      params.put("superseded", superseded);
+      params.put("oldSeq", seq);
+      params.put("survivingId", survivingId);
+      params.put("newSeq", newSeq);
+      nbsTemplate.update(UPDATE_SUPERSEDED_NAME_TO_SURVIVING, params);
+    }
+  }
+
+  private int getMaxSequenceForPerson(String personUid) {
+    Map<String, Object> params = Collections.singletonMap("personUid", personUid);
+    Integer maxSequence = nbsTemplate.queryForObject(FIND_MAX_SEQUENCE_PERSON_NAME, params, Integer.class);
+    return maxSequence == null ? 0 : maxSequence;
+  }
+
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandlerTest.java
@@ -1,0 +1,83 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PersonNamesMergeHandlerTest {
+
+  @Mock
+  private NamedParameterJdbcTemplate nbsTemplate;
+
+  private PersonNamesMergeHandler handler;
+
+  private static final String SURVIVING_PERSON_UID = "100";
+  private static final String SUPERSEDED_PERSON_UID_1 = "200";
+  private static final String SUPERSEDED_PERSON_UID_2 = "300";
+  private static final String MATCH_ID = "123";
+
+  @BeforeEach
+  void setUp() {
+    handler = new PersonNamesMergeHandler(nbsTemplate);
+  }
+
+  @Test
+  void handleMerge_shouldPerformAllPersonNameRelatedDatabaseOperations() {
+    // Surviving person has seq 1 (selected) and seq 2 (not selected)
+    // Superseded persons each have seq 1 to move
+    List<PatientMergeRequest.NameId> names = Arrays.asList(
+        new PatientMergeRequest.NameId(SURVIVING_PERSON_UID, "1"),
+        new PatientMergeRequest.NameId(SUPERSEDED_PERSON_UID_1, "1"),
+        new PatientMergeRequest.NameId(SUPERSEDED_PERSON_UID_2, "1")
+    );
+
+    PatientMergeRequest request = getPatientMergeRequest(names);
+
+    mockMaxSequenceQueryToReturn(2);
+    handler.handleMerge(MATCH_ID, request);
+    verifyInactiveSurvivingNames();
+    verifySupersededNameMoves();
+  }
+
+  @SuppressWarnings("unchecked")
+  private void mockMaxSequenceQueryToReturn(int maxSequence) {
+    when(nbsTemplate.queryForObject(
+        eq(PersonNamesMergeHandler.FIND_MAX_SEQUENCE_PERSON_NAME),
+        any(Map.class),
+        eq(Integer.class)
+    )).thenReturn(maxSequence);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void verifyInactiveSurvivingNames() {
+    ArgumentCaptor<Map<String, Object>> inactiveParamsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(nbsTemplate).update(
+        eq(PersonNamesMergeHandler.UPDATE_SELECTED_EXCLUDED_NAMES_INACTIVE),
+        inactiveParamsCaptor.capture()
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  private void verifySupersededNameMoves() {
+    ArgumentCaptor<Map<String, Object>> moveParamsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(nbsTemplate, times(2)).update(
+        eq(PersonNamesMergeHandler.UPDATE_SUPERSEDED_NAME_TO_SURVIVING),
+        moveParamsCaptor.capture()
+    );
+  }
+
+  private PatientMergeRequest getPatientMergeRequest(List<PatientMergeRequest.NameId> names) {
+    return new PatientMergeRequest(SURVIVING_PERSON_UID, null, names, null, null, null, null);
+  }
+}


### PR DESCRIPTION

Updates the `person_name` table to reassign selected names to the surviving patient

1- Names selected in the Surviving patient are not modified
2- Names de-selected in the Surviving patient are marked as INACTIVE
3- Names selected in Superseded patients have the person_name entries person_uid updated to the Surviving patient’s person_uid
4- Names de-selected in Superseded patients are not modified

## JIRA
https://cdc-nbs.atlassian.net/browse/CND-338