### PR TITLE
Implement phone & emai merge logic for patient merge API

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandler.java
@@ -87,23 +87,6 @@ public class PersonAddressMergeHandler implements SectionMergeHandler {
         AND class_cd = 'PST';
       """;
 
-  static final String UPDATE_LOCATORS_HIST_TO_SURVIVING = """
-      UPDATE Entity_loc_participation_hist
-      SET entity_uid = :survivingId,
-          last_chg_time = GETDATE()
-      WHERE locator_uid IN (:selectedLocators)
-        AND entity_uid != :survivingId
-        AND use_cd NOT IN ('BIR', 'DTH')
-        AND class_cd = 'PST';
-      """;
-
-  static final String DELETE_OLD_LOCATORS = """
-      DELETE FROM Entity_locator_participation
-      WHERE locator_uid IN (:selectedLocators)
-        AND entity_uid != :survivingId
-        AND use_cd NOT IN ('BIR', 'DTH')
-        AND class_cd = 'PST';
-      """;
 
   public PersonAddressMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
     this.nbsTemplate = nbsTemplate;
@@ -140,8 +123,6 @@ public class PersonAddressMergeHandler implements SectionMergeHandler {
     params.put("selectedLocators", selectedLocators);
 
     nbsTemplate.update(INSERT_NEW_LOCATORS, params);
-    nbsTemplate.update(UPDATE_LOCATORS_HIST_TO_SURVIVING, params);
-    nbsTemplate.update(DELETE_OLD_LOCATORS, params);
   }
 
 

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandler.java
@@ -85,22 +85,6 @@ public class PersonPhoneEmailMergeHandler implements SectionMergeHandler {
         AND class_cd = 'TELE';
       """;
 
-  static final String UPDATE_PHONE_EMAIL_LOCATORS_HIST_TO_SURVIVING = """
-      UPDATE Entity_loc_participation_hist
-      SET entity_uid = :survivingId,
-          last_chg_time = GETDATE()
-      WHERE locator_uid IN (:selectedLocators)
-        AND entity_uid != :survivingId
-        AND class_cd = 'TELE';
-      """;
-
-  static final String DELETE_OLD_PHONE_EMAIL_LOCATORS = """
-      DELETE FROM Entity_locator_participation
-      WHERE locator_uid IN (:selectedLocators)
-        AND entity_uid != :survivingId
-        AND class_cd = 'TELE'';
-      """;
-
 
   public PersonPhoneEmailMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
     this.nbsTemplate = nbsTemplate;
@@ -137,8 +121,6 @@ public class PersonPhoneEmailMergeHandler implements SectionMergeHandler {
     params.put("selectedLocators", selectedLocators);
 
     nbsTemplate.update(INSERT_NEW_PHONE_EMAIL_LOCATORS, params);
-    nbsTemplate.update(UPDATE_PHONE_EMAIL_LOCATORS_HIST_TO_SURVIVING, params);
-    nbsTemplate.update(DELETE_OLD_PHONE_EMAIL_LOCATORS, params);
   }
 
 

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandler.java
@@ -1,0 +1,145 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@Order(5)
+public class PersonPhoneEmailMergeHandler implements SectionMergeHandler {
+
+  private final NamedParameterJdbcTemplate nbsTemplate;
+
+  static final String UPDATE_UN_SELECTED_PHONE_EMAIL_INACTIVE = """
+      UPDATE Entity_locator_participation
+      SET record_status_cd = 'INACTIVE',
+         last_chg_time = GETDATE()
+      WHERE entity_uid = :survivingId
+        AND locator_uid NOT IN (:selectedLocators)
+        AND class_cd = 'TELE';
+      """;
+
+  static final String INSERT_NEW_PHONE_EMAIL_LOCATORS = """
+      INSERT INTO Entity_locator_participation (
+          entity_uid,
+          locator_uid,
+          version_ctrl_nbr,
+          add_reason_cd,
+          add_time,
+          add_user_id,
+          cd,
+          cd_desc_txt,
+          class_cd,
+          duration_amt,
+          duration_unit_cd,
+          from_time,
+          last_chg_reason_cd,
+          last_chg_time,
+          last_chg_user_id,
+          locator_desc_txt,
+          record_status_cd,
+          record_status_time,
+          status_cd,
+          status_time,
+          to_time,
+          use_cd,
+          user_affiliation_txt,
+          valid_time_txt,
+          as_of_date
+      )
+      SELECT
+          :survivingId,
+          locator_uid,
+          version_ctrl_nbr,
+          add_reason_cd,
+          add_time,
+          add_user_id,
+          cd,
+          cd_desc_txt,
+          class_cd,
+          duration_amt,
+          duration_unit_cd,
+          from_time,
+          last_chg_reason_cd,
+          GETDATE(),
+          last_chg_user_id,
+          locator_desc_txt,
+          record_status_cd,
+          record_status_time,
+          status_cd,
+          status_time,
+          to_time,
+          use_cd,
+          user_affiliation_txt,
+          valid_time_txt,
+          as_of_date
+      FROM Entity_locator_participation
+      WHERE locator_uid IN (:selectedLocators)
+        AND entity_uid != :survivingId
+        AND class_cd = 'TELE';
+      """;
+
+  static final String UPDATE_PHONE_EMAIL_LOCATORS_HIST_TO_SURVIVING = """
+      UPDATE Entity_loc_participation_hist
+      SET entity_uid = :survivingId,
+          last_chg_time = GETDATE()
+      WHERE locator_uid IN (:selectedLocators)
+        AND entity_uid != :survivingId
+        AND class_cd = 'TELE';
+      """;
+
+  static final String DELETE_OLD_PHONE_EMAIL_LOCATORS = """
+      DELETE FROM Entity_locator_participation
+      WHERE locator_uid IN (:selectedLocators)
+        AND entity_uid != :survivingId
+        AND class_cd = 'TELE'';
+      """;
+
+
+  public PersonPhoneEmailMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
+    this.nbsTemplate = nbsTemplate;
+  }
+
+  @Override
+  public void handleMerge(String matchId, PatientMergeRequest request) {
+    mergePersonPhoneEmail(request);
+  }
+
+  private void mergePersonPhoneEmail(PatientMergeRequest request) {
+    String survivingId = request.survivingRecord();
+    List<String> selectedLocatorIds = request.phoneEmails().stream()
+        .map(PatientMergeRequest.PhoneEmailId::locatorId)
+        .toList();
+
+    if (!selectedLocatorIds.isEmpty()) {
+      markUnselectedPhoneEmailInactive(survivingId, selectedLocatorIds);
+      updateSelectedPhoneEmail(survivingId, selectedLocatorIds);
+    }
+  }
+
+  private void markUnselectedPhoneEmailInactive(String survivingId, List<String> selectedLocators) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("survivingId", survivingId);
+    params.put("selectedLocators", selectedLocators);
+
+    nbsTemplate.update(UPDATE_UN_SELECTED_PHONE_EMAIL_INACTIVE, params);
+  }
+
+  private void updateSelectedPhoneEmail(String survivingId, List<String> selectedLocators) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("survivingId", survivingId);
+    params.put("selectedLocators", selectedLocators);
+
+    nbsTemplate.update(INSERT_NEW_PHONE_EMAIL_LOCATORS, params);
+    nbsTemplate.update(UPDATE_PHONE_EMAIL_LOCATORS_HIST_TO_SURVIVING, params);
+    nbsTemplate.update(DELETE_OLD_PHONE_EMAIL_LOCATORS, params);
+  }
+
+
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandlerTest.java
@@ -51,20 +51,6 @@ class PersonAddressMergeHandlerTest {
               List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
         }));
 
-    verify(nbsTemplate).update(eq(PersonAddressMergeHandler.UPDATE_LOCATORS_HIST_TO_SURVIVING),
-        (Map<String, Object>) argThat(params -> {
-          Map<String, Object> paramMap = (Map<String, Object>) params;
-          return survivingId.equals(paramMap.get("survivingId")) &&
-              List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
-        }));
-
-    verify(nbsTemplate).update(eq(PersonAddressMergeHandler.DELETE_OLD_LOCATORS),
-        (Map<String, Object>) argThat(params -> {
-          Map<String, Object> paramMap = (Map<String, Object>) params;
-          return survivingId.equals(paramMap.get("survivingId")) &&
-              List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
-        }));
-
   }
 
   private PatientMergeRequest getPatientMergeRequest(String survivingId) {

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandlerTest.java
@@ -72,7 +72,7 @@ class PersonNamesMergeHandlerTest {
   private void verifySupersededNameMoves() {
     ArgumentCaptor<Map<String, Object>> moveParamsCaptor = ArgumentCaptor.forClass(Map.class);
     verify(nbsTemplate, times(2)).update(
-        eq(PersonNamesMergeHandler.UPDATE_SUPERSEDED_NAME_TO_SURVIVING),
+        eq(PersonNamesMergeHandler.COPY_PERSON_NAME_TO_SURVIVING),
         moveParamsCaptor.capture()
     );
   }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
@@ -1,0 +1,81 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PersonPhoneEmailMergeHandlerTest {
+
+  @Mock
+  private NamedParameterJdbcTemplate nbsTemplate;
+
+  private PersonPhoneEmailMergeHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new PersonPhoneEmailMergeHandler(nbsTemplate);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void handleMerge_shouldPerformAllPersonPhoneEmailRelatedDatabaseOperations() {
+    String survivingId = "survivorId1";
+    String matchId = "match123";
+    PatientMergeRequest request = getPatientMergeRequest(survivingId);
+
+    handler.handleMerge(matchId, request);
+
+    verify(nbsTemplate).update(eq(PersonPhoneEmailMergeHandler.UPDATE_UN_SELECTED_PHONE_EMAIL_INACTIVE),
+        (Map<String, Object>) argThat(params -> {
+          Map<String, Object> paramMap = (Map<String, Object>) params;
+          return survivingId.equals(paramMap.get("survivingId")) &&
+              List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
+        }));
+
+    verify(nbsTemplate).update(eq(PersonPhoneEmailMergeHandler.INSERT_NEW_PHONE_EMAIL_LOCATORS),
+        (Map<String, Object>) argThat(params -> {
+          Map<String, Object> paramMap = (Map<String, Object>) params;
+          return survivingId.equals(paramMap.get("survivingId")) &&
+              List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
+        }));
+
+    verify(nbsTemplate).update(eq(PersonPhoneEmailMergeHandler.UPDATE_PHONE_EMAIL_LOCATORS_HIST_TO_SURVIVING),
+        (Map<String, Object>) argThat(params -> {
+          Map<String, Object> paramMap = (Map<String, Object>) params;
+          return survivingId.equals(paramMap.get("survivingId")) &&
+              List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
+        }));
+
+    verify(nbsTemplate).update(eq(PersonPhoneEmailMergeHandler.DELETE_OLD_PHONE_EMAIL_LOCATORS),
+        (Map<String, Object>) argThat(params -> {
+          Map<String, Object> paramMap = (Map<String, Object>) params;
+          return survivingId.equals(paramMap.get("survivingId")) &&
+              List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
+        }));
+
+  }
+
+  private PatientMergeRequest getPatientMergeRequest(String survivingId) {
+    List<PatientMergeRequest.PhoneEmailId> PhoneEmailIds = Arrays.asList(
+        new PatientMergeRequest.PhoneEmailId("locator1"),
+        new PatientMergeRequest.PhoneEmailId("locator2")
+    );
+    return new PatientMergeRequest(survivingId, null,
+        null, null, PhoneEmailIds, null, null);
+  }
+
+
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
@@ -52,20 +52,6 @@ class PersonPhoneEmailMergeHandlerTest {
               List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
         }));
 
-    verify(nbsTemplate).update(eq(PersonPhoneEmailMergeHandler.UPDATE_PHONE_EMAIL_LOCATORS_HIST_TO_SURVIVING),
-        (Map<String, Object>) argThat(params -> {
-          Map<String, Object> paramMap = (Map<String, Object>) params;
-          return survivingId.equals(paramMap.get("survivingId")) &&
-              List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
-        }));
-
-    verify(nbsTemplate).update(eq(PersonPhoneEmailMergeHandler.DELETE_OLD_PHONE_EMAIL_LOCATORS),
-        (Map<String, Object>) argThat(params -> {
-          Map<String, Object> paramMap = (Map<String, Object>) params;
-          return survivingId.equals(paramMap.get("survivingId")) &&
-              List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
-        }));
-
   }
 
   private PatientMergeRequest getPatientMergeRequest(String survivingId) {

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
@@ -69,12 +69,12 @@ class PersonPhoneEmailMergeHandlerTest {
   }
 
   private PatientMergeRequest getPatientMergeRequest(String survivingId) {
-    List<PatientMergeRequest.PhoneEmailId> PhoneEmailIds = Arrays.asList(
+    List<PatientMergeRequest.PhoneEmailId> phoneEmailIds = Arrays.asList(
         new PatientMergeRequest.PhoneEmailId("locator1"),
         new PatientMergeRequest.PhoneEmailId("locator2")
     );
     return new PatientMergeRequest(survivingId, null,
-        null, null, PhoneEmailIds, null, null);
+        null, null, phoneEmailIds, null, null);
   }
 
 


### PR DESCRIPTION
Implement phone & emai merge logic for patient merge API

1- Phone / Emails selected in the Surviving patient are not modified
2- Phone / Emails de-selected in the Surviving patient are marked as INACTIVE or LOG_DEL whichever is standard
3- Phone / Emails selected in Superseded patients have the entity_locator_participation entries entity_uid updated to the Surviving patient’s person_uid
4- Phone / Emails de-selected in Superseded patients are not modified

## JIRA
https://cdc-nbs.atlassian.net/browse/CND-340
