### PR TITLE
Implement Identification record merge into surviving patient

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonIdentificationsMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonIdentificationsMergeHandler.java
@@ -1,0 +1,174 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+@Order(6)
+public class PersonIdentificationsMergeHandler implements SectionMergeHandler {
+
+  private final NamedParameterJdbcTemplate nbsTemplate;
+
+  static final String UPDATE_ALL_PERSON_IDENTIFICATION_INACTIVE = """
+      UPDATE Entity_id
+      SET record_status_cd = 'INACTIVE',
+          last_chg_time = GETDATE()
+      WHERE entity_uid = :personUid
+      """;
+
+  static final String UPDATE_SELECTED_EXCLUDED_IDENTIFICATION_INACTIVE = """
+      UPDATE Entity_id
+      SET record_status_cd = 'INACTIVE',
+          last_chg_time = GETDATE()
+      WHERE entity_uid = :personUid
+        AND entity_id_seq NOT IN (:sequences)
+      """;
+
+  static final String FIND_MAX_SEQUENCE_PERSON_IDENTIFICATION = """
+      SELECT MAX(entity_id_seq)
+      FROM Entity_id
+      WHERE entity_uid = :personUid
+      """;
+
+  static final String COPY_ENTITY_ID_TO_SURVIVING = """
+      INSERT INTO entity_id (
+          entity_uid,
+          entity_id_seq,
+          add_reason_cd,
+          add_time,
+          add_user_id,
+          assigning_authority_cd,
+          assigning_authority_desc_txt,
+          duration_amt,
+          duration_unit_cd,
+          effective_from_time,
+          effective_to_time,
+          last_chg_reason_cd,
+          last_chg_time,
+          last_chg_user_id,
+          record_status_cd,
+          record_status_time,
+          root_extension_txt,
+          status_cd,
+          status_time,
+          type_cd,
+          type_desc_txt,
+          user_affiliation_txt,
+          valid_from_time,
+          valid_to_time,
+          as_of_date,
+          assigning_authority_id_type
+      )
+      SELECT
+          :survivingId AS entity_uid,
+          :newSeq AS entity_id_seq,
+          'MERGE' AS add_reason_cd,
+          GETDATE() AS add_time,
+          add_user_id,
+          assigning_authority_cd,
+          assigning_authority_desc_txt,
+          duration_amt,
+          duration_unit_cd,
+          effective_from_time,
+          effective_to_time,
+          last_chg_reason_cd,
+          GETDATE() AS last_chg_time,
+          last_chg_user_id,
+          'ACTIVE' AS record_status_cd,
+          GETDATE() AS record_status_time,
+          root_extension_txt,
+          status_cd,
+          status_time,
+          type_cd,
+          type_desc_txt,
+          user_affiliation_txt,
+          valid_from_time,
+          valid_to_time,
+          as_of_date,
+          assigning_authority_id_type
+      FROM entity_id
+      WHERE entity_uid = :supersededUid
+        AND entity_id_seq = :oldSeq
+      """;
+
+  public PersonIdentificationsMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
+    this.nbsTemplate = nbsTemplate;
+  }
+
+  @Override
+  public void handleMerge(String matchId, PatientMergeRequest request) {
+    mergePersonIdentifications(request.survivingRecord(), request.identifications());
+  }
+
+  private void mergePersonIdentifications(String survivorId,
+      List<PatientMergeRequest.IdentificationId> identifications) {
+    List<Integer> survivingIdentificationsSequences = new ArrayList<>();
+    Map<String, List<Integer>> supersededIdentifications = new HashMap<>();
+    categorizeIdentifications(survivorId, identifications, survivingIdentificationsSequences,
+        supersededIdentifications);
+    markUnselectedIdentificationsInactive(survivorId, survivingIdentificationsSequences);
+    updateSupersededIdentifications(survivorId, supersededIdentifications);
+  }
+
+  private void categorizeIdentifications(String survivorId, List<PatientMergeRequest.IdentificationId> identifications,
+      List<Integer> survivingSequences, Map<String, List<Integer>> supersededIdentifications) {
+    for (PatientMergeRequest.IdentificationId identification : identifications) {
+      String personUid = identification.personUid();
+      Integer seq = Integer.parseInt(identification.sequence());
+
+      if (personUid.equals(survivorId)) {
+        survivingSequences.add(seq);
+      } else {
+        supersededIdentifications.computeIfAbsent(personUid, k -> new ArrayList<>()).add(seq);
+      }
+    }
+  }
+
+  private void markUnselectedIdentificationsInactive(String survivorId, List<Integer> selectedSequences) {
+    String query =
+        selectedSequences.isEmpty() ?
+            UPDATE_ALL_PERSON_IDENTIFICATION_INACTIVE :
+            UPDATE_SELECTED_EXCLUDED_IDENTIFICATION_INACTIVE;
+    Map<String, Object> params = new HashMap<>();
+    params.put("personUid", survivorId);
+    if (!selectedSequences.isEmpty()) {
+      params.put("sequences", selectedSequences);
+    }
+    nbsTemplate.update(query, params);
+  }
+
+
+  private void updateSupersededIdentifications(String survivorId,
+      Map<String, List<Integer>> supersededIdentifications) {
+    for (Map.Entry<String, List<Integer>> entry : supersededIdentifications.entrySet()) {
+      copySupersededIdentificationsToSurviving(entry.getKey(), entry.getValue(), survivorId);
+    }
+  }
+
+  private void copySupersededIdentificationsToSurviving(String supersededUid, List<Integer> sequences,
+      String survivingId) {
+    int survivingMaxSeq = getMaxSequenceForPerson(survivingId);
+
+    for (Integer seq : sequences) {
+      int newSeq = ++survivingMaxSeq;
+      Map<String, Object> params = new HashMap<>();
+      params.put("supersededUid", supersededUid);
+      params.put("oldSeq", seq);
+      params.put("survivingId", survivingId);
+      params.put("newSeq", newSeq);
+
+      nbsTemplate.update(COPY_ENTITY_ID_TO_SURVIVING, params);
+    }
+  }
+
+  private int getMaxSequenceForPerson(String personUid) {
+    Map<String, Object> params = Collections.singletonMap("personUid", personUid);
+    Integer maxSequence = nbsTemplate.queryForObject(FIND_MAX_SEQUENCE_PERSON_IDENTIFICATION, params, Integer.class);
+    return maxSequence == null ? 0 : maxSequence;
+  }
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonIdentificationsMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonIdentificationsMergeHandlerTest.java
@@ -1,0 +1,87 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PersonIdentificationsMergeHandlerTest {
+
+  @Mock
+  private NamedParameterJdbcTemplate nbsTemplate;
+
+  private PersonIdentificationsMergeHandler handler;
+
+  private static final String SURVIVING_PERSON_UID = "100";
+  private static final String SUPERSEDED_PERSON_UID_1 = "200";
+  private static final String SUPERSEDED_PERSON_UID_2 = "300";
+  private static final String MATCH_ID = "123";
+
+  @BeforeEach
+  void setUp() {
+    handler = new PersonIdentificationsMergeHandler(nbsTemplate);
+  }
+
+  @Test
+  void handleMerge_shouldPerformAllPersonIdentificationRelatedDatabaseOperations() {
+    // Surviving person has seq 1 (selected) and seq 2 (not selected)
+    // Superseded persons each have seq 1 to move
+    List<PatientMergeRequest.IdentificationId> identifications = Arrays.asList(
+        new PatientMergeRequest.IdentificationId(SURVIVING_PERSON_UID, "1"),
+        new PatientMergeRequest.IdentificationId(SUPERSEDED_PERSON_UID_1, "1"),
+        new PatientMergeRequest.IdentificationId(SUPERSEDED_PERSON_UID_2, "1")
+    );
+
+    PatientMergeRequest request = getPatientMergeRequest(identifications);
+
+    mockMaxSequenceQueryToReturn(2);
+    handler.handleMerge(MATCH_ID, request);
+    verifyInactiveSurvivingIdentifications();
+    verifySupersededIdentificationsMoves();
+  }
+
+  @SuppressWarnings("unchecked")
+  private void mockMaxSequenceQueryToReturn(int maxSequence) {
+    when(nbsTemplate.queryForObject(
+        eq(PersonIdentificationsMergeHandler.FIND_MAX_SEQUENCE_PERSON_IDENTIFICATION),
+        any(Map.class),
+        eq(Integer.class)
+    )).thenReturn(maxSequence);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void verifyInactiveSurvivingIdentifications() {
+    ArgumentCaptor<Map<String, Object>> inactiveParamsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(nbsTemplate).update(
+        eq(PersonIdentificationsMergeHandler.UPDATE_SELECTED_EXCLUDED_IDENTIFICATION_INACTIVE),
+        inactiveParamsCaptor.capture()
+    );
+  }
+
+  @SuppressWarnings("unchecked")
+  private void verifySupersededIdentificationsMoves() {
+    ArgumentCaptor<Map<String, Object>> moveParamsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(nbsTemplate, times(2)).update(
+        eq(PersonIdentificationsMergeHandler.COPY_ENTITY_ID_TO_SURVIVING),
+        moveParamsCaptor.capture()
+    );
+  }
+
+  private PatientMergeRequest getPatientMergeRequest(List<PatientMergeRequest.IdentificationId> identifications) {
+    return new PatientMergeRequest(SURVIVING_PERSON_UID, null, null, null,
+        null, identifications, null);
+  }
+}


### PR DESCRIPTION
Implement Identification record merge into surviving patient:

1-Identifications selected in the Surviving patient are not modified
2-Identifications de-selected in the Surviving patient are marked as INACTIVE or LOG_DEL whichever is standard
3-Identifications selected in Superseded patients are copied into new records on the Surviving patient
4-Identifications de-selected in Superseded patients are not modified

## JIRA
https://cdc-nbs.atlassian.net/browse/CND-341
