### PR TITLE
implement race merging for patient merge process

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonRacesMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonRacesMergeHandler.java
@@ -1,0 +1,200 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+
+import java.util.*;
+
+@Component
+@Order(7)
+public class PersonRacesMergeHandler implements SectionMergeHandler {
+
+
+  static final String UPDATE_ALL_SURVIVOR_RACES_INACTIVE = """
+      UPDATE person_race
+      SET record_status_cd = 'INACTIVE',
+          last_chg_time = GETDATE()
+      WHERE person_uid = :survivorId
+        AND record_status_cd = 'ACTIVE'
+      """;
+  static final String UPDATE_SELECTED_EXCLUDED_RACES_INACTIVE = """
+      UPDATE person_race
+      SET record_status_cd = 'INACTIVE',
+          last_chg_time = GETDATE()
+      WHERE person_uid = :survivorId
+        AND record_status_cd = 'ACTIVE'
+        AND race_cd NOT IN (:survivingSelectedRaceCodes)
+      """;
+
+  static final String SELECT_ACTIVE_RACE_CATEGORIES = """
+      SELECT DISTINCT race_category_cd
+      FROM person_race
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String INSERT_NEW_DETAILED_RACE = """
+      INSERT INTO person_race (
+          person_uid, race_cd, race_category_cd,
+          add_reason_cd, add_time, add_user_id,
+          last_chg_reason_cd, last_chg_time, last_chg_user_id,
+          race_desc_txt, record_status_cd, record_status_time,
+          user_affiliation_txt, as_of_date
+      )
+      SELECT
+          :survivorId, race_cd, race_category_cd,
+          add_reason_cd, add_time, add_user_id,
+          'merge', GETDATE(), last_chg_user_id,
+          race_desc_txt, record_status_cd, record_status_time,
+          user_affiliation_txt, as_of_date
+      FROM Person_race pr
+      WHERE pr.person_uid = :supersededUid
+        AND pr.race_category_cd = :raceCategoryCd
+        AND pr.race_cd = :selectedRaceCd
+        AND pr.record_status_cd = 'ACTIVE'
+        AND NOT EXISTS (
+            SELECT 1
+            FROM Person_race pr2
+            WHERE pr2.person_uid = :survivorId
+              AND pr2.race_cd = pr.race_cd
+        )
+      """;
+
+  static final String MOVE_NEW_RACE_CATEGORY_TO_SURVIVOR = """
+      UPDATE person_race
+      SET person_uid = :survivorId,
+          last_chg_time = GETDATE()
+      WHERE person_uid = :supersededUid
+        AND race_category_cd = :raceCategoryCd
+        AND race_cd = :selectedRaceCd
+      """;
+
+  static final String SELECT_RACE_CATEGORY_FOR_RACE_CD = """
+      SELECT DISTINCT race_category_cd
+      FROM person_race
+      WHERE race_cd = :raceCd
+      """;
+
+  final NamedParameterJdbcTemplate nbsTemplate;
+
+  public PersonRacesMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
+    this.nbsTemplate = nbsTemplate;
+  }
+
+  //Merge modifications have been applied to the person races
+  @Override
+  public void handleMerge(String matchId, PatientMergeRequest request) {
+    mergePersonRaces(request.survivingRecord(), request.races());
+  }
+
+  private void mergePersonRaces(String survivorId, List<PatientMergeRequest.RaceId> races) {
+    List<String> survivingSelectedRaceCodes = new ArrayList<>();
+    Map<String, List<String>> supersededRaceMap = new HashMap<>();
+
+    categorizeRaces(survivorId, races, supersededRaceMap, survivingSelectedRaceCodes);
+    markUnselectedSurvivingRacesAsInactive(survivorId, survivingSelectedRaceCodes);
+
+    List<String> survivingRaceCategories = getRaceCategoriesForSurvivor(survivorId);
+    processSupersededRaces(survivorId, supersededRaceMap, survivingRaceCategories);
+  }
+
+  private void categorizeRaces(String survivorId, List<PatientMergeRequest.RaceId> races,
+      Map<String, List<String>> supersededRaceMap, List<String> survivingSelectedRaceCodes) {
+
+    for (PatientMergeRequest.RaceId race : races) {
+      String personUid = race.personUid();
+      String raceCode = race.raceCode();
+
+      if (personUid.equals(survivorId)) {
+        survivingSelectedRaceCodes.add(raceCode);
+      } else {
+        supersededRaceMap.computeIfAbsent(personUid, k -> new ArrayList<>()).add(raceCode);
+      }
+    }
+  }
+
+  private void markUnselectedSurvivingRacesAsInactive(String survivorId, List<String> survivingSelectedRaceCodes) {
+    String query = survivingSelectedRaceCodes.isEmpty() ? UPDATE_ALL_SURVIVOR_RACES_INACTIVE :
+        UPDATE_SELECTED_EXCLUDED_RACES_INACTIVE;
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("survivorId", survivorId);//NOSONAR
+    if (!survivingSelectedRaceCodes.isEmpty()) {
+      params.put("survivingSelectedRaceCodes", survivingSelectedRaceCodes);
+    }
+    nbsTemplate.update(query, params);
+  }
+
+  private List<String> getRaceCategoriesForSurvivor(String survivorId) {
+    return nbsTemplate.queryForList(SELECT_ACTIVE_RACE_CATEGORIES,
+        new MapSqlParameterSource("survivorId", survivorId), String.class);
+  }
+
+  private void processSupersededRaces(String survivorId, Map<String, List<String>> supersededRaceMap,
+      List<String> survivingRaceCategories) {
+
+    for (Map.Entry<String, List<String>> entry : supersededRaceMap.entrySet()) {
+      String supersededUid = entry.getKey();
+      List<String> selectedRaceCodes = entry.getValue();
+      processRaceCodesForSuperseded(survivorId, supersededUid, selectedRaceCodes, survivingRaceCategories);
+    }
+  }
+
+  private void processRaceCodesForSuperseded(String survivorId, String supersededUid, List<String> raceCodes,
+      List<String> survivingRaceCategories) {
+
+    Set<String> processedCategories = new HashSet<>();
+
+    for (String raceCd : raceCodes) {
+      String raceCategoryCd = getRaceCategoryCd(raceCd);
+      if (processedCategories.contains(raceCategoryCd))
+        continue;
+
+      handleRaceCategory(survivorId, supersededUid, raceCategoryCd, survivingRaceCategories, raceCd);
+      processedCategories.add(raceCategoryCd);
+    }
+  }
+
+  private void handleRaceCategory(String survivorId, String supersededUid, String raceCategoryCd,
+      List<String> survivingRaceCategories, String selectedRaceCd) {
+
+    if (survivingRaceCategories.contains(raceCategoryCd)) {
+      addNewDetailedRaceToSurviving(survivorId, supersededUid, raceCategoryCd, selectedRaceCd);
+    } else {
+      moveRaceToSurviving(survivorId, supersededUid, raceCategoryCd, selectedRaceCd);
+    }
+  }
+
+  private void addNewDetailedRaceToSurviving(String survivorId, String supersededUid, String raceCategoryCd,
+      String selectedRaceCd) {
+
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("survivorId", survivorId);
+    params.addValue("supersededUid", supersededUid);
+    params.addValue("raceCategoryCd", raceCategoryCd);
+    params.addValue("selectedRaceCd", selectedRaceCd);
+
+    nbsTemplate.update(INSERT_NEW_DETAILED_RACE, params);
+  }
+
+  private void moveRaceToSurviving(String survivorId, String supersededUid, String raceCategoryCd,
+      String selectedRaceCd) {
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("survivorId", survivorId);
+    params.addValue("supersededUid", supersededUid);
+    params.addValue("raceCategoryCd", raceCategoryCd);
+    params.addValue("selectedRaceCd", selectedRaceCd);
+
+    nbsTemplate.update(MOVE_NEW_RACE_CATEGORY_TO_SURVIVOR, params);
+  }
+
+
+  private String getRaceCategoryCd(String raceCd) {
+    return nbsTemplate.queryForObject(SELECT_RACE_CATEGORY_FOR_RACE_CD,
+        new MapSqlParameterSource("raceCd", raceCd), String.class);
+  }
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonRacesMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonRacesMergeHandlerTest.java
@@ -1,0 +1,118 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PersonRacesMergeHandlerTest {
+
+  private PersonRacesMergeHandler handler;
+
+  private static final String SURVIVOR_ID = "survivor-100";
+  private static final String SUPERSEDED_ID = "superseded-200";
+  private static final String SURVIVOR_RACE_CODE = "RACE_001";
+  private static final String SUPERSEDED_RACE_CODE = "RACE_002";
+  private static final String EXISTING_CATEGORY = "EXISTING_CATEGORY";
+  private static final String NEW_CATEGORY = "NEW_CATEGORY";
+
+  @Mock
+  private NamedParameterJdbcTemplate nbsTemplate;
+
+  @Captor
+  private ArgumentCaptor<Map<String, Object>> paramMapCaptor;
+
+  @Captor
+  private ArgumentCaptor<MapSqlParameterSource> paramSourceCaptor;
+
+
+  @BeforeEach
+  void setUp() {
+    handler = new PersonRacesMergeHandler(nbsTemplate);
+  }
+
+  @Test
+  void shouldAddDetailedRace_whenSurvivorContainsTheCategory() {
+    List<PatientMergeRequest.RaceId> races = Arrays.asList(
+        new PatientMergeRequest.RaceId(SURVIVOR_ID, SURVIVOR_RACE_CODE),
+        new PatientMergeRequest.RaceId(SUPERSEDED_ID, SUPERSEDED_RACE_CODE)
+    );
+
+    PatientMergeRequest request = getPatientMergeRequest(races);
+
+    mockSurvivorRaceCategories(List.of(EXISTING_CATEGORY));
+    mockRaceCategoryCd(EXISTING_CATEGORY);
+
+    handler.handleMerge("match-123", request);
+
+    verifyUnselectedSurvivingRacesMarkedInactive();
+    verifyNewDetailedRaceInserted();
+    verify(nbsTemplate, never()).update(eq(PersonRacesMergeHandler.MOVE_NEW_RACE_CATEGORY_TO_SURVIVOR), anyMap());
+  }
+
+  @Test
+  void shouldMoveRace_whenSurvivorDoesNotContainTheCategory() {
+    List<PatientMergeRequest.RaceId> races = Arrays.asList(
+        new PatientMergeRequest.RaceId(SURVIVOR_ID, SURVIVOR_RACE_CODE),
+        new PatientMergeRequest.RaceId(SUPERSEDED_ID, SUPERSEDED_RACE_CODE)
+    );
+
+    PatientMergeRequest request = getPatientMergeRequest(races);
+
+    mockSurvivorRaceCategories(Collections.singletonList(EXISTING_CATEGORY));
+    mockRaceCategoryCd(NEW_CATEGORY);
+
+    handler.handleMerge("match-123", request);
+
+    verifyUnselectedSurvivingRacesMarkedInactive();
+    verifyNewRaceCategoryMovedToSurvivor();
+    verify(nbsTemplate, never()).update(eq(PersonRacesMergeHandler.INSERT_NEW_DETAILED_RACE), anyMap());
+  }
+
+  private void mockSurvivorRaceCategories(List<String> categories) {
+    when(nbsTemplate.queryForList(anyString(), any(MapSqlParameterSource.class), eq(String.class)))
+        .thenReturn(categories);
+  }
+
+  //Mock that a race_cd maps to the given category
+  private void mockRaceCategoryCd(String categoryCd) {
+    when(nbsTemplate.queryForObject(anyString(), any(MapSqlParameterSource.class), eq(String.class)))
+        .thenReturn(categoryCd);
+  }
+
+  private void verifyUnselectedSurvivingRacesMarkedInactive() {
+    verify(nbsTemplate).update(eq(PersonRacesMergeHandler.UPDATE_SELECTED_EXCLUDED_RACES_INACTIVE),
+        paramMapCaptor.capture());
+  }
+
+  private void verifyNewDetailedRaceInserted() {
+    verify(nbsTemplate).update(eq(PersonRacesMergeHandler.INSERT_NEW_DETAILED_RACE),
+        paramSourceCaptor.capture());
+  }
+
+  private void verifyNewRaceCategoryMovedToSurvivor() {
+    verify(nbsTemplate).update(eq(PersonRacesMergeHandler.MOVE_NEW_RACE_CATEGORY_TO_SURVIVOR),
+        paramSourceCaptor.capture());
+  }
+
+  private PatientMergeRequest getPatientMergeRequest(List<PatientMergeRequest.RaceId> races) {
+    return new PatientMergeRequest(SURVIVOR_ID, null, null, null, null, null, races);
+  }
+
+}


### PR DESCRIPTION

- Selected race entries are copied to the surviving patient
1- Races selected in the Surviving patient are not modified
2- Races de-selected in the Surviving patient are marked as INACTIVE or LOG_DEL whichever is standard
3- Races selected in Superseded patients are added to the Surviving patient 
4- Races de-selected in Superseded patients are not modified


## JIRA
https://cdc-nbs.atlassian.net/browse/CND-342