### PR TITLE
Implement Ethnicity merge logic for patient merge API

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonEthnicityMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonEthnicityMergeHandler.java
@@ -97,7 +97,7 @@ public class PersonEthnicityMergeHandler implements SectionMergeHandler {
 
   private void updatePersonEthnicityIndicator(String survivorId, String ethnicitySourcePersonId) {
     MapSqlParameterSource parameters = new MapSqlParameterSource();
-    parameters.addValue("survivorId", survivorId);
+    parameters.addValue("survivorId", survivorId);//NOSONAR
     parameters.addValue("ethnicitySourcePersonId", ethnicitySourcePersonId);
     nbsTemplate.update(UPDATE_PERSON_ETHNICITY_IND, parameters);
   }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonEthnicityMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonEthnicityMergeHandler.java
@@ -1,0 +1,153 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+@Component
+@Order(7)
+public class PersonEthnicityMergeHandler implements SectionMergeHandler {
+
+
+  static final String UPDATE_PERSON_ETHNICITY_IND = """
+      UPDATE person
+      SET ethnic_group_ind = (
+          SELECT ethnic_group_ind
+          FROM person
+          WHERE person_uid = :ethnicitySourcePersonId
+      ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd='merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String FETCH_SUPERSEDED_PERSON_ETHNICITY_IND = """
+      SELECT ethnic_group_ind
+      FROM person
+      WHERE person_uid = :personUid
+      """;
+
+  static final String UPDATE_PRE_EXISTING_ENTRIES_TO_INACTIVE = """
+      UPDATE person_ethnic_group
+      SET
+        record_status_cd = 'INACTIVE',
+        last_chg_time = GETDATE(),
+        last_chg_reason_cd='merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String COPY_SUPERSEDED_ETHNIC_GROUPS_TO_SURVIVING = """
+      INSERT INTO person_ethnic_group (
+          person_uid,
+          ethnic_group_cd,
+          add_reason_cd,
+          add_time,
+          add_user_id,
+          ethnic_group_desc_txt,
+          last_chg_reason_cd,
+          last_chg_time,
+          last_chg_user_id,
+          record_status_cd,
+          record_status_time,
+          user_affiliation_txt
+      )
+      SELECT
+          :survivorId,
+          ethnic_group_cd,
+          add_reason_cd,
+          GETDATE(),
+          add_user_id,
+          ethnic_group_desc_txt,
+          'merge',
+          GETDATE(),
+          last_chg_user_id,
+          record_status_cd,
+          record_status_time,
+          user_affiliation_txt
+      FROM person_ethnic_group
+      WHERE person_uid = :supersededId
+        AND record_status_cd = 'ACTIVE'
+      """;
+
+  static final String FETCH_ETHNICITY_INDICATORS_FOR_COMPARISON = """
+      SELECT
+          (SELECT ethnic_group_ind FROM person WHERE person_uid = :survivorId) AS survivorIndicator,
+          (SELECT ethnic_group_ind FROM person WHERE person_uid = :supersededId) AS supersededIndicator
+      """;
+
+
+  final NamedParameterJdbcTemplate nbsTemplate;
+
+  public PersonEthnicityMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
+    this.nbsTemplate = nbsTemplate;
+  }
+
+  //Merge modifications have been applied to the person ethnicity
+  @Override
+  public void handleMerge(String matchId, PatientMergeRequest request) {
+    if (!ethnicityIndicatorsAreEqual(request.survivingRecord(), request.ethnicitySource())) {
+      mergePersonEthnicity(request.survivingRecord(), request.ethnicitySource());
+    }
+  }
+
+  private boolean ethnicityIndicatorsAreEqual(String survivorId, String supersededId) {
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("survivorId", survivorId);//NOSONAR
+    params.addValue("supersededId", supersededId);
+
+    Map<String, Object> result = nbsTemplate.queryForMap(FETCH_ETHNICITY_INDICATORS_FOR_COMPARISON, params);
+
+    String survivorIndicator = String.valueOf(result.get("survivorIndicator"));
+    String supersededIndicator = String.valueOf(result.get("supersededIndicator"));
+
+    return Objects.equals(survivorIndicator, supersededIndicator);
+  }
+
+
+  private void mergePersonEthnicity(String survivorId, String ethnicitySourcePersonId) {
+    updatePersonEthnicityIndicator(survivorId, ethnicitySourcePersonId);
+    updatePreexistingEntriesToInactive(survivorId);
+    if (!isEthnicityIndicatorNull(ethnicitySourcePersonId)) {
+      copySupersededEntriesToSurviving(survivorId, ethnicitySourcePersonId);
+    }
+  }
+
+
+  private void updatePersonEthnicityIndicator(String survivorId, String ethnicitySourcePersonId) {
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+    parameters.addValue("survivorId", survivorId);//NOSONAR
+    parameters.addValue("ethnicitySourcePersonId", ethnicitySourcePersonId);
+    nbsTemplate.update(UPDATE_PERSON_ETHNICITY_IND, parameters);
+  }
+
+  private void updatePreexistingEntriesToInactive(String survivorId) {
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+    parameters.addValue("survivorId", survivorId);
+    nbsTemplate.update(UPDATE_PRE_EXISTING_ENTRIES_TO_INACTIVE, parameters);
+  }
+
+
+  private boolean isEthnicityIndicatorNull(String personUid) {
+    String ethnicityInd = nbsTemplate.queryForObject(
+        FETCH_SUPERSEDED_PERSON_ETHNICITY_IND,
+        new MapSqlParameterSource("personUid", personUid),
+        String.class
+    );
+    return ethnicityInd == null || ethnicityInd.isBlank();
+  }
+
+  private void copySupersededEntriesToSurviving(String survivorId, String supersededId) {
+    MapSqlParameterSource parameters = new MapSqlParameterSource();
+    parameters.addValue("survivorId", survivorId);
+    parameters.addValue("supersededId", supersededId);
+
+    nbsTemplate.update(COPY_SUPERSEDED_ETHNIC_GROUPS_TO_SURVIVING, parameters);
+  }
+
+
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/PatientMergeRequest.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/PatientMergeRequest.java
@@ -9,17 +9,27 @@ public record PatientMergeRequest(
     List<AddressId> addresses,
     List<PhoneEmailId> phoneEmails,
     List<IdentificationId> identifications,
-    List<RaceId> races
+    List<RaceId> races,
+    String ethnicitySource
 ) {
 
-  public record NameId(String personUid, String sequence) {}
+  public record NameId(String personUid, String sequence) {
+  }
 
-  public record AddressId(String locatorId) {}
 
-  public record PhoneEmailId(String locatorId) {}
+  public record AddressId(String locatorId) {
+  }
 
-  public record IdentificationId(String personUid, String sequence) {}
 
-  public record RaceId(String personUid, String raceCode) {}
+  public record PhoneEmailId(String locatorId) {
+  }
+
+
+  public record IdentificationId(String personUid, String sequence) {
+  }
+
+
+  public record RaceId(String personUid, String raceCode) {
+  }
 
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/AdminCommentMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/AdminCommentMergeHandlerTest.java
@@ -42,7 +42,7 @@ class AdminCommentMergeHandlerTest {
 
   private PatientMergeRequest getPatientMergeRequest() {
     return new PatientMergeRequest("survivorId1", "adminCommentSourcePersonId",
-        null, null, null, null, null);
+        null, null, null, null, null, null);
   }
 
   private void verifyUpdateAdministrativeComments() {

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandlerTest.java
@@ -59,7 +59,7 @@ class PersonAddressMergeHandlerTest {
         new PatientMergeRequest.AddressId("locator2")
     );
     return new PatientMergeRequest(survivingId, null,
-        null, addressIds, null, null, null);
+        null, addressIds, null, null, null, null);
   }
 
 

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonEthnicityMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonEthnicityMergeHandlerTest.java
@@ -10,9 +10,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -35,21 +32,9 @@ class PersonEthnicityMergeHandlerTest {
     when(patientMergeRequest.ethnicitySource()).thenReturn("supersededId");
   }
 
-  @Test
-  void handleMerge_WhenEthnicityIndicatorsAreEqual_ShouldNotPerformMerge() {
-    // Ethnicity indicators are equal
-    mockFetchEthnicityIndicators("2135-3", "2135-3");
-
-    handler.handleMerge("matchId", patientMergeRequest);
-
-    verify(nbsTemplate, never()).update(any(String.class), any(MapSqlParameterSource.class));
-  }
 
   @Test
   void handleMerge_WhenEthnicityIndicatorsAreDifferent_ShouldPerformMerge() {
-    // Ethnicity indicators are different
-    mockFetchEthnicityIndicators("2135-2", "2135-5");
-
     when(nbsTemplate.queryForObject(
         eq(PersonEthnicityMergeHandler.FETCH_SUPERSEDED_PERSON_ETHNICITY_IND),
         any(MapSqlParameterSource.class),
@@ -66,14 +51,4 @@ class PersonEthnicityMergeHandlerTest {
         any(MapSqlParameterSource.class));
   }
 
-  private void mockFetchEthnicityIndicators(String survivorIndicator, String supersededIndicator) {
-    Map<String, Object> indicatorResult = new HashMap<>();
-    indicatorResult.put("survivorIndicator", survivorIndicator);
-    indicatorResult.put("supersededIndicator", supersededIndicator);
-
-    when(nbsTemplate.queryForMap(
-        eq(PersonEthnicityMergeHandler.FETCH_ETHNICITY_INDICATORS_FOR_COMPARISON),
-        any(MapSqlParameterSource.class)))
-        .thenReturn(indicatorResult);
-  }
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonEthnicityMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonEthnicityMergeHandlerTest.java
@@ -1,0 +1,79 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PersonEthnicityMergeHandlerTest {
+
+  @Mock
+  private NamedParameterJdbcTemplate nbsTemplate;
+
+  @Mock
+  private PatientMergeRequest patientMergeRequest;
+
+  private PersonEthnicityMergeHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    handler = new PersonEthnicityMergeHandler(nbsTemplate);
+    when(patientMergeRequest.survivingRecord()).thenReturn("survivorId");
+    when(patientMergeRequest.ethnicitySource()).thenReturn("supersededId");
+  }
+
+  @Test
+  void handleMerge_WhenEthnicityIndicatorsAreEqual_ShouldNotPerformMerge() {
+    // Ethnicity indicators are equal
+    mockFetchEthnicityIndicators("2135-3", "2135-3");
+
+    handler.handleMerge("matchId", patientMergeRequest);
+
+    verify(nbsTemplate, never()).update(any(String.class), any(MapSqlParameterSource.class));
+  }
+
+  @Test
+  void handleMerge_WhenEthnicityIndicatorsAreDifferent_ShouldPerformMerge() {
+    // Ethnicity indicators are different
+    mockFetchEthnicityIndicators("2135-2", "2135-5");
+
+    when(nbsTemplate.queryForObject(
+        eq(PersonEthnicityMergeHandler.FETCH_SUPERSEDED_PERSON_ETHNICITY_IND),
+        any(MapSqlParameterSource.class),
+        eq(String.class)))
+        .thenReturn("2135-5");
+
+    handler.handleMerge("matchId", patientMergeRequest);
+
+    verify(nbsTemplate).update(eq(PersonEthnicityMergeHandler.UPDATE_PERSON_ETHNICITY_IND),
+        any(MapSqlParameterSource.class));
+    verify(nbsTemplate).update(eq(PersonEthnicityMergeHandler.UPDATE_PRE_EXISTING_ENTRIES_TO_INACTIVE),
+        any(MapSqlParameterSource.class));
+    verify(nbsTemplate).update(eq(PersonEthnicityMergeHandler.COPY_SUPERSEDED_ETHNIC_GROUPS_TO_SURVIVING),
+        any(MapSqlParameterSource.class));
+  }
+
+  private void mockFetchEthnicityIndicators(String survivorIndicator, String supersededIndicator) {
+    Map<String, Object> indicatorResult = new HashMap<>();
+    indicatorResult.put("survivorIndicator", survivorIndicator);
+    indicatorResult.put("supersededIndicator", supersededIndicator);
+
+    when(nbsTemplate.queryForMap(
+        eq(PersonEthnicityMergeHandler.FETCH_ETHNICITY_INDICATORS_FOR_COMPARISON),
+        any(MapSqlParameterSource.class)))
+        .thenReturn(indicatorResult);
+  }
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonIdentificationsMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonIdentificationsMergeHandlerTest.java
@@ -82,6 +82,6 @@ class PersonIdentificationsMergeHandlerTest {
 
   private PatientMergeRequest getPatientMergeRequest(List<PatientMergeRequest.IdentificationId> identifications) {
     return new PatientMergeRequest(SURVIVING_PERSON_UID, null, null, null,
-        null, identifications, null);
+        null, identifications, null,null);
   }
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandlerTest.java
@@ -78,6 +78,6 @@ class PersonNamesMergeHandlerTest {
   }
 
   private PatientMergeRequest getPatientMergeRequest(List<PatientMergeRequest.NameId> names) {
-    return new PatientMergeRequest(SURVIVING_PERSON_UID, null, names, null, null, null, null);
+    return new PatientMergeRequest(SURVIVING_PERSON_UID, null, names, null, null, null, null, null);
   }
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
@@ -60,7 +60,7 @@ class PersonPhoneEmailMergeHandlerTest {
         new PatientMergeRequest.PhoneEmailId("locator2")
     );
     return new PatientMergeRequest(survivingId, null,
-        null, null, phoneEmailIds, null, null);
+        null, null, phoneEmailIds, null, null, null);
   }
 
 

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonRacesMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonRacesMergeHandlerTest.java
@@ -115,7 +115,7 @@ class PersonRacesMergeHandlerTest {
   }
 
   private PatientMergeRequest getPatientMergeRequest(List<PatientMergeRequest.RaceId> races) {
-    return new PatientMergeRequest(SURVIVOR_ID, null, null, null, null, null, races);
+    return new PatientMergeRequest(SURVIVOR_ID, null, null, null, null, null, races, null);
   }
 
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandlerTest.java
@@ -77,7 +77,8 @@ class PersonTableMergeHandlerTest {
   }
 
   private void verifyLinkSupersededChildIdsToSurvivor() {
-    verify(nbsTemplate).update(eq(QueryConstants.LINK_SUPERSEDED_CHILD_IDS_TO_SURVIVOR), any(MapSqlParameterSource.class));
+    verify(nbsTemplate).update(eq(QueryConstants.LINK_SUPERSEDED_CHILD_IDS_TO_SURVIVOR),
+        any(MapSqlParameterSource.class));
   }
 
   private void verifyMarkSupersededRecordsAsSuperseded() {
@@ -85,7 +86,8 @@ class PersonTableMergeHandlerTest {
   }
 
   private void verifyUpdateLastChangeTimeForPatients() {
-    verify(nbsTemplate).update(eq(QueryConstants.UPDATE_LAST_CHANGE_TIME_FOR_PATIENTS), any(MapSqlParameterSource.class));
+    verify(nbsTemplate).update(eq(QueryConstants.UPDATE_LAST_CHANGE_TIME_FOR_PATIENTS),
+        any(MapSqlParameterSource.class));
   }
 
   private void verifyInsertPersonMergeRecord() {
@@ -97,7 +99,7 @@ class PersonTableMergeHandlerTest {
   }
 
   private PatientMergeRequest getPatientMergeRequest() {
-    return new PatientMergeRequest("survivorId1", null, null, null, null, null, null);
+    return new PatientMergeRequest("survivorId1", null, null, null, null, null, null, null);
   }
 
 }


### PR DESCRIPTION
Implement Ethnicity merge logic for patient merge API
1.Ethnicity selected in the Surviving patient are not modified
2.Ethnicity de-selected in the Surviving patient are marked as INACTIVE or LOG_DEL whichever is standard
3.Ethnicity selected in Superseded patients have the person_ethnic_group entry copied to the Surviving patient
4.Ethnicity de-selected in Superseded patients are not modified

## JIRA
https://cdc-nbs.atlassian.net/browse/CND-343