### PR TITLE
Prevent duplicate container startup

### DIFF
--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/config/container/MsSqlContainerInitializer.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/config/container/MsSqlContainerInitializer.java
@@ -12,18 +12,25 @@ class MsSqlContainerInitializer implements ApplicationContextInitializer<Configu
 
   public static final Network network = Network.newNetwork();
 
+  public static JdbcDatabaseContainer<?> container = null;
+
   @Override
   @SuppressWarnings("resource") // We don't want to close this
   public void initialize(@NonNull final ConfigurableApplicationContext context) {
+    if (container != null) {
+      return;
+    }
+
     String image = context.getEnvironment().getProperty("testing.database.mssql.image", "dataingestion-di-mssql");
     String username = context.getEnvironment().getProperty("testing.database.mssql.username");
     String password = context.getEnvironment().getProperty("testing.database.mssql.password");
 
-    JdbcDatabaseContainer<?> container = new NbsDatabaseContainer<>(image)
+    container = new NbsDatabaseContainer<>(image)
         .withUsername(username)
         .withPassword(password)
         .withNetwork(network)
         .withNetworkAliases("mssql")
+        .withExposedPorts(1433)
         .withImagePullPolicy(PullPolicy.defaultPolicy());
 
     container.start();

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/config/container/RecordLinkageInitializer.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/config/container/RecordLinkageInitializer.java
@@ -7,17 +7,23 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 
 class RecordLinkageInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+  private static GenericContainer<?> recordLinkageContainer;
 
   @Override
   @SuppressWarnings("resource") // We don't want to close these containers
   public void initialize(@NonNull final ConfigurableApplicationContext context) {
+    if (recordLinkageContainer != null) {
+      return;
+    }
+
     final Network network = MsSqlContainerInitializer.network;
 
-    final GenericContainer<?> recordLinkageContainer = new GenericContainer<>(
+    recordLinkageContainer = new GenericContainer<>(
         "ghcr.io/cdcgov/recordlinker:v25.8.0")
         .withExposedPorts(8070)
         .withEnv("PORT", "8070")
         .withNetwork(network)
+        .dependsOn(MsSqlContainerInitializer.container)
         .withNetworkAliases("recordLinkage");
 
     String username = System.getProperty("spring.datasource.mpi.username");


### PR DESCRIPTION
## Notes

1. Adds a static variable in the test container initializer to prevent duplicate containers from being started. 
2. Adds a dependency on the MSSQL container to the Record Linker container
3. Adds exposed port to MSSQL container to allow automatic "ready" check


## Checklist

- [ ] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?