### PR TITLE
Implement Patient-data merge logic for patient merge API

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonBirthAndSexMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonBirthAndSexMergeHandler.java
@@ -1,0 +1,305 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+@Component
+@Order(8)
+public class PersonBirthAndSexMergeHandler implements SectionMergeHandler {
+
+  static final String UPDATE_PERSON_AS_OF_SEX = """
+      UPDATE person
+      SET as_of_date_sex = (
+          SELECT as_of_date_sex
+          FROM person
+          WHERE person_uid = :sourceId
+      ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_BIRTH_TIME = """
+      UPDATE person
+      SET birth_time = (
+          SELECT birth_time
+          FROM person
+          WHERE person_uid = :sourceId
+      ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_ADDITIONAL_GENDER = """
+      UPDATE person
+      SET additional_gender_cd = (
+          SELECT additional_gender_cd
+          FROM person
+          WHERE person_uid = :sourceId
+      ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_BIRTH_ORDER = """
+      UPDATE person
+      SET birth_order_nbr = (
+          SELECT birth_order_nbr
+          FROM person
+          WHERE person_uid = :sourceId
+      ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_CURRENT_SEX_CD = """
+      UPDATE person
+      SET curr_sex_cd = (
+          SELECT curr_sex_cd
+          FROM person
+          WHERE person_uid = :sourceId
+      ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_SEX_UNKNOWN_CD = """
+      UPDATE person
+      SET sex_unk_reason_cd = (
+          SELECT sex_unk_reason_cd
+          FROM person
+          WHERE person_uid = :sourceId
+      ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_TRANSGENDER_CD = """
+      UPDATE person
+      SET preferred_gender_cd = (
+          SELECT preferred_gender_cd
+          FROM person
+          WHERE person_uid = :sourceId
+      ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_BIRTH_GENDER_CD = """
+      UPDATE person
+      SET birth_gender_cd = (
+          SELECT birth_gender_cd
+          FROM person
+          WHERE person_uid = :sourceId
+      ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_MULTIPLE_BIRTH_IND = """
+      UPDATE person
+      SET multiple_birth_ind = (
+          SELECT multiple_birth_ind
+          FROM person
+          WHERE person_uid = :sourceId
+      ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_UN_SELECTED_BIRTH_ADDRESS_INACTIVE = """
+      UPDATE Entity_locator_participation
+      SET record_status_cd = 'INACTIVE',
+          last_chg_time = GETDATE(),
+          last_chg_reason_cd = 'merge'
+      WHERE entity_uid = :survivingId
+        AND class_cd = 'PST'
+        AND use_cd = 'BIR';
+      """;
+
+  public static final String COPY_BIRTH_ADDRESS_FROM_SURVIVING_TO_SUPERSEDED = """
+      INSERT INTO Entity_locator_participation (
+          entity_uid,
+          locator_uid,
+          version_ctrl_nbr,
+          add_reason_cd,
+          add_time,
+          add_user_id,
+          cd,
+          cd_desc_txt,
+          class_cd,
+          duration_amt,
+          duration_unit_cd,
+          from_time,
+          last_chg_reason_cd,
+          last_chg_time,
+          last_chg_user_id,
+          locator_desc_txt,
+          record_status_cd,
+          record_status_time,
+          status_cd,
+          status_time,
+          to_time,
+          use_cd,
+          user_affiliation_txt,
+          valid_time_txt,
+          as_of_date
+      )
+      SELECT
+          :survivingId,
+          locator_uid,
+          version_ctrl_nbr,
+          add_reason_cd,
+          add_time,
+          add_user_id,
+          cd,
+          cd_desc_txt,
+          class_cd,
+          duration_amt,
+          duration_unit_cd,
+          from_time,
+          'merge',
+          GETDATE(),
+          last_chg_user_id,
+          locator_desc_txt,
+          record_status_cd,
+          record_status_time,
+          status_cd,
+          status_time,
+          to_time,
+          use_cd,
+          user_affiliation_txt,
+          valid_time_txt,
+          as_of_date
+      FROM Entity_locator_participation
+      WHERE entity_uid = :sourceId
+        AND use_cd     = 'BIR'
+        AND class_cd   = 'PST'
+      """;
+
+
+  final NamedParameterJdbcTemplate nbsTemplate;
+
+  public PersonBirthAndSexMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
+    this.nbsTemplate = nbsTemplate;
+  }
+
+  //Merge modifications have been applied to the person birth and sex
+  @Override
+  public void handleMerge(String matchId, PatientMergeRequest request) {
+    mergePersonBirthAndSex(request.survivingRecord(), request.sexAndBirthFieldSource());
+  }
+
+  private void mergePersonBirthAndSex(String survivorId, PatientMergeRequest.SexAndBirthFieldSource fieldSource) {
+    updateAsOf(survivorId, fieldSource.asOfSource());
+    updateDateOfBirth(survivorId, fieldSource.dateOfBirthSource());
+    updateAdditionalGender(survivorId, fieldSource.additionalGenderSource());
+    updateBirthOrder(survivorId, fieldSource.birthOrderSource());
+    updateCurrentSex(survivorId, fieldSource.currentSexSource());
+    updateSexUnknown(survivorId, fieldSource.sexUnknownSource());
+    updateTransgender(survivorId, fieldSource.transgenderSource());
+    updateBirthGender(survivorId, fieldSource.birthGenderSource());
+    updateMultipleBirth(survivorId, fieldSource.multipleBirthSource());
+    updateBirthAddress(survivorId, fieldSource.birthAddressSource());
+  }
+
+  private void updateAsOf(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_AS_OF_SEX);
+    }
+  }
+
+  private void updateDateOfBirth(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_BIRTH_TIME);
+    }
+  }
+
+  private void updateAdditionalGender(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_ADDITIONAL_GENDER);
+    }
+  }
+
+  private void updateBirthOrder(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_BIRTH_ORDER);
+    }
+  }
+
+  private void updateCurrentSex(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_CURRENT_SEX_CD);
+    }
+  }
+
+  private void updateSexUnknown(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_SEX_UNKNOWN_CD);
+    }
+  }
+
+  private void updateTransgender(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_TRANSGENDER_CD);
+    }
+  }
+
+  private void updateBirthGender(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_BIRTH_GENDER_CD);
+    }
+  }
+
+  private void updateMultipleBirth(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_MULTIPLE_BIRTH_IND);
+    }
+  }
+
+
+  private void updateBirthAddress(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      markUnselectedBirthAddressInactive(survivorId);
+      copyBirthAddressFromSupersededToSurviving(survivorId, sourceId);
+    }
+
+  }
+
+  private void markUnselectedBirthAddressInactive(String survivingId) {
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("survivingId", survivingId);
+    nbsTemplate.update(UPDATE_UN_SELECTED_BIRTH_ADDRESS_INACTIVE, params);
+  }
+
+  private void copyBirthAddressFromSupersededToSurviving(String survivingId, String sourceId) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("survivingId", survivingId);
+    params.put("sourceId", sourceId);
+    nbsTemplate.update(COPY_BIRTH_ADDRESS_FROM_SURVIVING_TO_SUPERSEDED, params);
+  }
+
+  private void updatePersonField(String survivorId, String sourceId, String sqlQuery) {
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("survivorId", survivorId);
+    params.addValue("sourceId", sourceId);
+    nbsTemplate.update(sqlQuery, params);
+  }
+
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonGeneralInfoMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonGeneralInfoMergeHandler.java
@@ -1,0 +1,227 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@Order(10)
+public class PersonGeneralInfoMergeHandler implements SectionMergeHandler {
+
+  static final String UPDATE_PERSON_GENERAL_AS_OF = """
+      UPDATE person
+         SET as_of_date_general = (
+             SELECT as_of_date_general
+               FROM person
+              WHERE person_uid = :sourceId
+         ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+       WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_MARITAL_STATUS_CD = """
+      UPDATE person
+         SET marital_status_cd = (
+             SELECT marital_status_cd
+               FROM person
+              WHERE person_uid = :sourceId
+         ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+       WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_MOTHERS_MAIDEN_NAME = """
+      UPDATE person
+         SET mothers_maiden_nm = (
+             SELECT mothers_maiden_nm
+               FROM person
+              WHERE person_uid = :sourceId
+         ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+       WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_NUMBER_OF_ADULTS = """
+      UPDATE person
+         SET adults_in_house_nbr = (
+             SELECT adults_in_house_nbr
+               FROM person
+              WHERE person_uid = :sourceId
+         ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+       WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_NUMBER_OF_CHILDREN = """
+      UPDATE person
+         SET children_in_house_nbr = (
+             SELECT children_in_house_nbr
+               FROM person
+              WHERE person_uid = :sourceId
+         ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+       WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_OCCUPATION_CD = """
+      UPDATE person
+         SET occupation_cd = (
+             SELECT occupation_cd
+               FROM person
+              WHERE person_uid = :sourceId
+         ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+       WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_EDUCATION_LEVEL_CD = """
+      UPDATE person
+         SET education_level_cd = (
+             SELECT education_level_cd
+               FROM person
+              WHERE person_uid = :sourceId
+         ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+       WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_PRIMARY_LANGUAGE_CD = """
+      UPDATE person
+         SET prim_lang_cd = (
+             SELECT prim_lang_cd
+               FROM person
+              WHERE person_uid = :sourceId
+         ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+       WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_SPEAKS_ENGLISH_CD = """
+      UPDATE person
+         SET speaks_english_cd = (
+             SELECT speaks_english_cd
+               FROM person
+              WHERE person_uid = :sourceId
+         ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+       WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_STATE_HIV_CASE_ID = """
+      UPDATE person
+         SET ehars_id = (
+             SELECT ehars_id
+               FROM person
+              WHERE person_uid = :sourceId
+         ),
+      last_chg_time = GETDATE(),
+      last_chg_reason_cd = 'merge'
+       WHERE person_uid = :survivorId
+      """;
+
+  private final NamedParameterJdbcTemplate nbsTemplate;
+
+  public PersonGeneralInfoMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
+    this.nbsTemplate = nbsTemplate;
+  }
+
+  @Override
+  public void handleMerge(String matchId, PatientMergeRequest request) {
+    mergePersonGeneralInfo(request.survivingRecord(), request.generalInfoFieldSource());
+  }
+
+  private void mergePersonGeneralInfo(String survivorId, PatientMergeRequest.GeneralInfoFieldSource fieldSource) {
+    updateAsOf(survivorId, fieldSource.asOfSource());
+    updateMaritalStatus(survivorId, fieldSource.maritalStatusSource());
+    updateMothersMaidenName(survivorId, fieldSource.mothersMaidenNameSource());
+    updateNumberOfAdults(survivorId, fieldSource.numberOfAdultsInResidenceSource());
+    updateNumberOfChildren(survivorId, fieldSource.numberOfChildrenInResidenceSource());
+    updatePrimaryOccupation(survivorId, fieldSource.primaryOccupationSource());
+    updateEducationLevel(survivorId, fieldSource.educationLevelSource());
+    updatePrimaryLanguage(survivorId, fieldSource.primaryLanguageSource());
+    updateSpeaksEnglish(survivorId, fieldSource.speaksEnglishSource());
+    updateStateHivCaseId(survivorId, fieldSource.stateHivCaseIdSource());
+  }
+
+
+  private void updateAsOf(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_GENERAL_AS_OF);
+    }
+  }
+
+  private void updateMaritalStatus(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_MARITAL_STATUS_CD);
+    }
+  }
+
+  private void updateMothersMaidenName(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_MOTHERS_MAIDEN_NAME);
+    }
+  }
+
+  private void updateNumberOfAdults(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_NUMBER_OF_ADULTS);
+    }
+  }
+
+  private void updateNumberOfChildren(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_NUMBER_OF_CHILDREN);
+    }
+  }
+
+  private void updatePrimaryOccupation(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_OCCUPATION_CD);
+    }
+  }
+
+  private void updateEducationLevel(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_EDUCATION_LEVEL_CD);
+    }
+  }
+
+  private void updatePrimaryLanguage(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_PRIMARY_LANGUAGE_CD);
+    }
+  }
+
+  private void updateSpeaksEnglish(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_SPEAKS_ENGLISH_CD);
+    }
+  }
+
+  private void updateStateHivCaseId(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_STATE_HIV_CASE_ID);
+    }
+  }
+
+
+  private void updatePersonField(String survivorId, String sourceId, String query) {
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("survivorId", survivorId);
+    params.addValue("sourceId", sourceId);
+    nbsTemplate.update(query, params);
+  }
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonMortalityMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonMortalityMergeHandler.java
@@ -1,0 +1,188 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@Order(9)
+public class PersonMortalityMergeHandler implements SectionMergeHandler {
+
+
+  static final String UPDATE_PERSON_AS_OF_DEATH = """
+      UPDATE person
+      SET as_of_date_morbidity = (
+              SELECT as_of_date_morbidity
+              FROM person
+              WHERE person_uid = :sourceId
+          ),
+          last_chg_time = GETDATE(),
+          last_chg_reason_cd = 'merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_DECEASED_IND = """
+      UPDATE person
+      SET deceased_ind_cd = (
+              SELECT deceased_ind_cd
+              FROM person
+              WHERE person_uid = :sourceId
+          ),
+          last_chg_time = GETDATE(),
+          last_chg_reason_cd = 'merge'
+      WHERE person_uid = :survivorId
+      """;
+
+  static final String UPDATE_PERSON_DATE_OF_DEATH = """
+      UPDATE person
+      SET deceased_time = (
+              SELECT deceased_time
+              FROM person
+              WHERE person_uid = :sourceId
+          ),
+          last_chg_time = GETDATE(),
+          last_chg_reason_cd = 'merge'
+      WHERE person_uid = :survivorId
+      """;
+  static final String UPDATE_UN_SELECTED_DEATH_ADDRESS_INACTIVE = """
+      UPDATE Entity_locator_participation
+      SET record_status_cd = 'INACTIVE',
+          last_chg_time = GETDATE(),
+          last_chg_reason_cd = 'merge'
+      WHERE entity_uid = :survivingId
+        AND use_cd = 'DTH'
+        AND class_cd = 'PST'
+      """;
+
+  static final String INSERT_NEW_DEATH_LOCATOR = """
+      INSERT INTO Entity_locator_participation (
+          entity_uid,
+          locator_uid,
+          version_ctrl_nbr,
+          add_reason_cd,
+          add_time,
+          add_user_id,
+          cd,
+          cd_desc_txt,
+          class_cd,
+          duration_amt,
+          duration_unit_cd,
+          from_time,
+          last_chg_reason_cd,
+          last_chg_time,
+          last_chg_user_id,
+          locator_desc_txt,
+          record_status_cd,
+          record_status_time,
+          status_cd,
+          status_time,
+          to_time,
+          use_cd,
+          user_affiliation_txt,
+          valid_time_txt,
+          as_of_date
+      )
+      SELECT
+          :survivingId,
+          locator_uid,
+          version_ctrl_nbr,
+          add_reason_cd,
+          add_time,
+          add_user_id,
+          cd,
+          cd_desc_txt,
+          class_cd,
+          duration_amt,
+          duration_unit_cd,
+          from_time,
+          'merge',
+          GETDATE(),
+          last_chg_user_id,
+          locator_desc_txt,
+          record_status_cd,
+          record_status_time,
+          status_cd,
+          status_time,
+          to_time,
+          use_cd,
+          user_affiliation_txt,
+          valid_time_txt,
+          as_of_date
+      FROM Entity_locator_participation
+      WHERE entity_uid = :sourceId
+        AND use_cd = 'DTH'
+        AND class_cd = 'PST'
+      """;
+
+  final NamedParameterJdbcTemplate nbsTemplate;
+
+  public PersonMortalityMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
+    this.nbsTemplate = nbsTemplate;
+  }
+
+  //Merge modifications have been applied to the person Mortality
+  public void handleMerge(String matchId, PatientMergeRequest request) {
+    mergePersonMortality(request.survivingRecord(), request.mortalityFieldSource());
+  }
+
+  private void mergePersonMortality(String survivorId, PatientMergeRequest.MortalityFieldSource fieldSource) {
+    updateAsOf(survivorId, fieldSource.asOfSource());
+    updateDeceasedFlag(survivorId, fieldSource.deceasedSource());
+    updateDateOfDeath(survivorId, fieldSource.dateOfDeathSource());
+    updateDeathAddress(survivorId, fieldSource.deathAddressSource());
+  }
+
+  private void updateAsOf(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_AS_OF_DEATH);
+    }
+  }
+
+  private void updateDeceasedFlag(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_DECEASED_IND);
+    }
+  }
+
+  private void updateDateOfDeath(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      updatePersonField(survivorId, sourceId, UPDATE_PERSON_DATE_OF_DEATH);
+    }
+  }
+
+  private void updateDeathAddress(String survivorId, String sourceId) {
+    if (!survivorId.equals(sourceId)) {
+      markUnselectedDeathAddressInactive(survivorId);
+      copyDeathAddressFromSupersededToSurviving(survivorId, sourceId);
+    }
+  }
+
+  private void markUnselectedDeathAddressInactive(String survivingId) {
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("survivingId", survivingId);
+    nbsTemplate.update(UPDATE_UN_SELECTED_DEATH_ADDRESS_INACTIVE, params);
+  }
+
+  private void copyDeathAddressFromSupersededToSurviving(String survivingId, String sourceId) {
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("survivingId", survivingId);
+    params.addValue("sourceId", sourceId);
+
+    nbsTemplate.update(INSERT_NEW_DEATH_LOCATOR, params);
+  }
+
+
+  private void updatePersonField(String survivorId, String sourceId, String query) {
+    MapSqlParameterSource params = new MapSqlParameterSource();
+    params.addValue("survivorId", survivorId);
+    params.addValue("sourceId", sourceId);
+    nbsTemplate.update(query, params);
+  }
+
+
+
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/PatientMergeRequest.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/PatientMergeRequest.java
@@ -10,7 +10,10 @@ public record PatientMergeRequest(
     List<PhoneEmailId> phoneEmails,
     List<IdentificationId> identifications,
     List<RaceId> races,
-    String ethnicitySource
+    String ethnicitySource,
+    SexAndBirthFieldSource sexAndBirthFieldSource,
+    MortalityFieldSource mortalityFieldSource,
+    GeneralInfoFieldSource generalInfoFieldSource
 ) {
 
   public record NameId(String personUid, String sequence) {
@@ -30,6 +33,45 @@ public record PatientMergeRequest(
 
 
   public record RaceId(String personUid, String raceCode) {
+  }
+
+
+  public record SexAndBirthFieldSource(
+      String asOfSource,
+      String dateOfBirthSource,
+      String currentSexSource,
+      String sexUnknownSource,
+      String transgenderSource,
+      String additionalGenderSource,
+      String birthGenderSource,
+      String multipleBirthSource,
+      String birthOrderSource,
+      String birthAddressSource
+  ) {
+  }
+
+
+  public record MortalityFieldSource(
+      String asOfSource,
+      String deceasedSource,
+      String dateOfDeathSource,
+      String deathAddressSource
+  ) {
+  }
+
+
+  public record GeneralInfoFieldSource(
+      String asOfSource,
+      String maritalStatusSource,
+      String mothersMaidenNameSource,
+      String numberOfAdultsInResidenceSource,
+      String numberOfChildrenInResidenceSource,
+      String primaryOccupationSource,
+      String educationLevelSource,
+      String primaryLanguageSource,
+      String speaksEnglishSource,
+      String stateHivCaseIdSource
+  ) {
   }
 
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/AdminCommentMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/AdminCommentMergeHandlerTest.java
@@ -42,7 +42,8 @@ class AdminCommentMergeHandlerTest {
 
   private PatientMergeRequest getPatientMergeRequest() {
     return new PatientMergeRequest("survivorId1", "adminCommentSourcePersonId",
-        null, null, null, null, null, null);
+        null, null, null, null, null, null,
+        null, null, null);
   }
 
   private void verifyUpdateAdministrativeComments() {

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandlerTest.java
@@ -59,7 +59,7 @@ class PersonAddressMergeHandlerTest {
         new PatientMergeRequest.AddressId("locator2")
     );
     return new PatientMergeRequest(survivingId, null,
-        null, addressIds, null, null, null, null);
+        null, addressIds, null, null, null, null, null, null, null);
   }
 
 

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonBirthAndSexMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonBirthAndSexMergeHandlerTest.java
@@ -1,0 +1,74 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+
+
+@ExtendWith(MockitoExtension.class)
+class PersonBirthAndSexMergeHandlerTest {
+
+  @Mock
+  private NamedParameterJdbcTemplate nbsTemplate;
+
+  private PersonBirthAndSexMergeHandler handler;
+
+  @Mock
+  private PatientMergeRequest mockRequest;
+
+  private static final String SURVIVOR_ID = "survivorId";
+  private static final String SOURCE_ID = "supersededId";
+
+  private PatientMergeRequest.SexAndBirthFieldSource fieldSourceWithDiffIds;
+  private PatientMergeRequest.SexAndBirthFieldSource fieldSourceWithSameIds;
+
+
+  @BeforeEach
+  void setUp() {
+    handler = new PersonBirthAndSexMergeHandler(nbsTemplate);
+
+    fieldSourceWithDiffIds = new PatientMergeRequest.SexAndBirthFieldSource(
+        SOURCE_ID, SOURCE_ID, SOURCE_ID, SOURCE_ID, SOURCE_ID, SOURCE_ID, SOURCE_ID,
+        SOURCE_ID, SOURCE_ID, SOURCE_ID
+    );
+
+    fieldSourceWithSameIds = new PatientMergeRequest.SexAndBirthFieldSource(
+        SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID,
+        SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID
+    );
+  }
+
+  @Test
+  void handleMerge_ShouldUpdatePersonBirthAndSexFields() {
+    when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
+    when(mockRequest.sexAndBirthFieldSource()).thenReturn(fieldSourceWithDiffIds);
+
+    handler.handleMerge("matchId", mockRequest);
+
+    verify(nbsTemplate, times(10)).update(anyString(), any(MapSqlParameterSource.class));
+  }
+
+  @Test
+  void handleMerge_NotCalledWhenSourceSameAsSurvivor() {
+    when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
+    when(mockRequest.sexAndBirthFieldSource()).thenReturn(fieldSourceWithSameIds);
+
+    handler.handleMerge("matchId", mockRequest);
+
+    verify(nbsTemplate, never()).update(anyString(), any(MapSqlParameterSource.class));
+  }
+
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonGeneralInfoMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonGeneralInfoMergeHandlerTest.java
@@ -1,0 +1,68 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+
+
+@ExtendWith(MockitoExtension.class)
+class PersonGeneralInfoMergeHandlerTest {
+
+  @Mock
+  private NamedParameterJdbcTemplate nbsTemplate;
+
+  private PersonGeneralInfoMergeHandler handler;
+
+  @Mock
+  private PatientMergeRequest mockRequest;
+
+  private static final String SURVIVOR_ID = "survivorId";
+  private static final String SOURCE_ID = "supersededId";
+
+  private PatientMergeRequest.GeneralInfoFieldSource fieldSourceWithDiffIds;
+  private PatientMergeRequest.GeneralInfoFieldSource fieldSourceWithSameIds;
+
+
+  @BeforeEach
+  void setUp() {
+    handler = new PersonGeneralInfoMergeHandler(nbsTemplate);
+
+    fieldSourceWithDiffIds = new PatientMergeRequest.GeneralInfoFieldSource(SOURCE_ID, SOURCE_ID,
+        SOURCE_ID, SOURCE_ID, SOURCE_ID, SOURCE_ID, SOURCE_ID, SOURCE_ID, SOURCE_ID, SOURCE_ID);
+
+
+    fieldSourceWithSameIds = new PatientMergeRequest.GeneralInfoFieldSource(SURVIVOR_ID, SURVIVOR_ID,
+        SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID);
+  }
+
+  @Test
+  void handleMerge_ShouldUpdatePersonGeneralInfoFields() {
+    when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
+    when(mockRequest.generalInfoFieldSource()).thenReturn(fieldSourceWithDiffIds);
+
+    handler.handleMerge("matchId", mockRequest);
+
+    verify(nbsTemplate, times(10)).update(anyString(), any(MapSqlParameterSource.class));
+  }
+
+  @Test
+  void handleMerge_NotCalledWhenSourceSameAsSurvivor() {
+    when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
+    when(mockRequest.generalInfoFieldSource()).thenReturn(fieldSourceWithSameIds);
+
+    handler.handleMerge("matchId", mockRequest);
+
+    verify(nbsTemplate, never()).update(anyString(), any(MapSqlParameterSource.class));
+  }
+
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonIdentificationsMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonIdentificationsMergeHandlerTest.java
@@ -82,6 +82,6 @@ class PersonIdentificationsMergeHandlerTest {
 
   private PatientMergeRequest getPatientMergeRequest(List<PatientMergeRequest.IdentificationId> identifications) {
     return new PatientMergeRequest(SURVIVING_PERSON_UID, null, null, null,
-        null, identifications, null,null);
+        null, identifications, null, null, null, null, null);
   }
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonMortalityMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonMortalityMergeHandlerTest.java
@@ -1,0 +1,68 @@
+package gov.cdc.nbs.deduplication.merge.handler;
+
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+
+
+@ExtendWith(MockitoExtension.class)
+class PersonMortalityMergeHandlerTest {
+
+  @Mock
+  private NamedParameterJdbcTemplate nbsTemplate;
+
+  private PersonMortalityMergeHandler handler;
+
+
+  @Mock
+  private PatientMergeRequest mockRequest;
+
+  private static final String SURVIVOR_ID = "survivorId";
+  private static final String SOURCE_ID = "supersededId";
+
+  private PatientMergeRequest.MortalityFieldSource fieldSourceWithDiffIds;
+  private PatientMergeRequest.MortalityFieldSource fieldSourceWithSameIds;
+
+
+  @BeforeEach
+  void setUp() {
+    handler = new PersonMortalityMergeHandler(nbsTemplate);
+
+    fieldSourceWithDiffIds =
+        new PatientMergeRequest.MortalityFieldSource(SOURCE_ID, SOURCE_ID, SOURCE_ID, SOURCE_ID);
+
+    fieldSourceWithSameIds =
+        new PatientMergeRequest.MortalityFieldSource(SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID, SURVIVOR_ID);
+  }
+
+  @Test
+  void handleMerge_ShouldUpdatePersonMortalityFields() {
+    when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
+    when(mockRequest.mortalityFieldSource()).thenReturn(fieldSourceWithDiffIds);
+
+    handler.handleMerge("matchId", mockRequest);
+
+    verify(nbsTemplate, times(5)).update(anyString(), any(MapSqlParameterSource.class));
+  }
+
+  @Test
+  void handleMerge_NotCalledWhenSourceSameAsSurvivor() {
+    when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
+    when(mockRequest.mortalityFieldSource()).thenReturn(fieldSourceWithSameIds);
+
+    handler.handleMerge("matchId", mockRequest);
+
+    verify(nbsTemplate, never()).update(anyString(), any(MapSqlParameterSource.class));
+  }
+
+}

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandlerTest.java
@@ -78,6 +78,6 @@ class PersonNamesMergeHandlerTest {
   }
 
   private PatientMergeRequest getPatientMergeRequest(List<PatientMergeRequest.NameId> names) {
-    return new PatientMergeRequest(SURVIVING_PERSON_UID, null, names, null, null, null, null, null);
+    return new PatientMergeRequest(SURVIVING_PERSON_UID, null, names, null, null, null, null, null, null, null, null);
   }
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
@@ -60,7 +60,8 @@ class PersonPhoneEmailMergeHandlerTest {
         new PatientMergeRequest.PhoneEmailId("locator2")
     );
     return new PatientMergeRequest(survivingId, null,
-        null, null, phoneEmailIds, null, null, null);
+        null, null, phoneEmailIds, null, null, null,
+        null, null, null);
   }
 
 

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonRacesMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonRacesMergeHandlerTest.java
@@ -115,7 +115,7 @@ class PersonRacesMergeHandlerTest {
   }
 
   private PatientMergeRequest getPatientMergeRequest(List<PatientMergeRequest.RaceId> races) {
-    return new PatientMergeRequest(SURVIVOR_ID, null, null, null, null, null, races, null);
+    return new PatientMergeRequest(SURVIVOR_ID, null, null, null, null, null, races, null, null, null, null);
   }
 
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandlerTest.java
@@ -99,7 +99,8 @@ class PersonTableMergeHandlerTest {
   }
 
   private PatientMergeRequest getPatientMergeRequest() {
-    return new PatientMergeRequest("survivorId1", null, null, null, null, null, null, null);
+    return new PatientMergeRequest("survivorId1", null, null, null, null, null,
+        null, null, null, null, null);
   }
 
 }


### PR DESCRIPTION
Implement Patient-data merge logic for patient merge API
1.Data from the selected Sex & birth section is copied to the Surviving patient
2.Data from the selected Mortality section is copied to the Surviving patient 
3.Data from the selected General patient information section is copied to the Surviving patient


## JIRA

https://cdc-nbs.atlassian.net/browse/CND-344