### PR TITLE
Persist a detailed record of the merge to support un-merge process

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/MergeService.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/MergeService.java
@@ -1,20 +1,53 @@
 package gov.cdc.nbs.deduplication.merge;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cdc.nbs.deduplication.merge.handler.SectionMergeHandler;
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
-@RequiredArgsConstructor
 public class MergeService {
 
+  private static final String SAVE_PATIENT_MERGE_AUDIT_SQL = """
+          INSERT INTO patient_merge_audit (
+              survivor_id,
+              superseded_ids,
+              merge_time,
+              related_table_audits_json,
+              patient_merge_request_json
+          )
+          VALUES (
+              :survivorId,
+              :supersededIds,
+              GETDATE(),
+              :relatedAuditsJson,
+              :mergeRequestJson
+          )
+      """;
+
+
+
   private final List<SectionMergeHandler> handlers;
+  private final NamedParameterJdbcTemplate nbsTemplate;
+  private final ObjectMapper objectMapper;
+
+  public MergeService(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate,
+      List<SectionMergeHandler> handlers,
+      ObjectMapper objectMapper) {
+    this.handlers = handlers;
+    this.nbsTemplate = nbsTemplate;
+    this.objectMapper = objectMapper;
+  }
 
   @Transactional
   public void performMerge(Long matchId, PatientMergeRequest request) {
@@ -22,8 +55,38 @@ public class MergeService {
     List<SectionMergeHandler> orderedHandlers = new ArrayList<>(handlers);
     AnnotationAwareOrderComparator.sort(orderedHandlers);
 
+    PatientMergeAudit patientMergeAudit = initPatientMergeAudit(request);
+
     for (SectionMergeHandler handler : orderedHandlers) {
-      handler.handleMerge(matchIdStr, request);
+      handler.handleMerge(matchIdStr, request, patientMergeAudit);
+    }
+    saveAuditToDatabase(patientMergeAudit);
+  }
+
+  private PatientMergeAudit initPatientMergeAudit(PatientMergeRequest request) {
+    PatientMergeAudit patientMergeAudit = new PatientMergeAudit();
+    patientMergeAudit.setPatientMergeRequest(request);
+    patientMergeAudit.setSurvivorId(request.survivingRecord());
+    patientMergeAudit.setRelatedTableAudits(new ArrayList<>());
+    return patientMergeAudit;
+  }
+
+  private void saveAuditToDatabase(PatientMergeAudit audit) {
+    try {
+      String relatedAuditsJson = objectMapper.writeValueAsString(audit.getRelatedTableAudits());
+      String mergeRequestJson = objectMapper.writeValueAsString(audit.getPatientMergeRequest());
+
+      Map<String, Object> params = new HashMap<>();
+      params.put("survivorId", audit.getSurvivorId());
+      params.put("supersededIds", String.join(",", audit.getSupersededIds()));
+      params.put("relatedAuditsJson", relatedAuditsJson);
+      params.put("mergeRequestJson", mergeRequestJson);
+
+
+      nbsTemplate.update(SAVE_PATIENT_MERGE_AUDIT_SQL, params);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);//NOSONAR
     }
   }
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/AdminCommentMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/AdminCommentMergeHandler.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
 import gov.cdc.nbs.deduplication.constants.QueryConstants;
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
@@ -20,7 +21,7 @@ public class AdminCommentMergeHandler implements SectionMergeHandler {
 
   //Merge modifications have been applied to the Administrative Comments
   @Override
-  public void handleMerge(String matchId, PatientMergeRequest request) {
+  public void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit patientMergeAudit) {
     String survivorId = request.survivingRecord();
     String adminCommentsSourcePersonUid = request.adminCommentsSource();
     updateAdministrativeComments(survivorId, adminCommentsSourcePersonUid);

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandler.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
-import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import gov.cdc.nbs.deduplication.merge.model.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -87,43 +87,103 @@ public class PersonAddressMergeHandler implements SectionMergeHandler {
         AND class_cd = 'PST';
       """;
 
+  private static final String FIND_SELECTED_LOCATORS_FOR_INSERT = """
+      SELECT locator_uid
+      FROM Entity_locator_participation
+      WHERE locator_uid IN (:selectedLocators)
+        AND entity_uid != :survivingId
+        AND use_cd NOT IN ('BIR', 'DTH')
+        AND class_cd = 'PST'
+      """;
+
+  private static final String FIND_UNSELECTED_ADDRESSES_FOR_AUDIT = """
+      SELECT entity_uid, locator_uid, record_status_cd
+      FROM Entity_locator_participation
+      WHERE entity_uid = :survivingId
+        AND locator_uid NOT IN (:selectedLocators)
+        AND use_cd NOT IN ('BIR', 'DTH')
+        AND class_cd = 'PST'
+      """;
 
   public PersonAddressMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
     this.nbsTemplate = nbsTemplate;
   }
 
   @Override
-  public void handleMerge(String matchId, PatientMergeRequest request) {
-    mergePersonAddress(request);
+  public void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit patientMergeAudit) {
+    mergePersonAddress(request, patientMergeAudit);
   }
 
-  private void mergePersonAddress(PatientMergeRequest request) {
+  private void mergePersonAddress(PatientMergeRequest request, PatientMergeAudit audit) {
     String survivingId = request.survivingRecord();
-    List<String> selectedLocatorIds = request.addresses().stream()
-        .map(PatientMergeRequest.AddressId::locatorId)
-        .toList();
+    List<String> selectedLocators = extractSelectedLocatorIds(request);
 
-    if (!selectedLocatorIds.isEmpty()) {
-      markUnselectedAddressInactive(survivingId, selectedLocatorIds);
-      updateSelectedAddress(survivingId, selectedLocatorIds);
+    if (!selectedLocators.isEmpty()) {
+      List<AuditUpdateAction> updateActions = performUnselectedAddressInactivation(survivingId, selectedLocators);
+      List<AuditInsertAction> insertActions = performSelectedAddressCopy(survivingId, selectedLocators);
+
+      audit.getRelatedTableAudits()
+          .add(new RelatedTableAudit("Entity_locator_participation", updateActions, insertActions));
     }
   }
 
-  private void markUnselectedAddressInactive(String survivingId, List<String> selectedLocators) {
-    Map<String, Object> params = new HashMap<>();
-    params.put("survivingId", survivingId);
-    params.put("selectedLocators", selectedLocators);
+  private List<String> extractSelectedLocatorIds(PatientMergeRequest request) {
+    return request.addresses().stream()
+        .map(PatientMergeRequest.AddressId::locatorId)
+        .toList();
+  }
+
+  private List<AuditUpdateAction> performUnselectedAddressInactivation(String survivingId,
+      List<String> selectedLocators) {
+    Map<String, Object> params = Map.of(
+        "survivingId", survivingId,//NOSONAR
+        "selectedLocators", selectedLocators//NOSONAR
+    );
+
+    List<Map<String, Object>> rowsToUpdate = fetchUnselectedAddressesForAudit(survivingId, selectedLocators);
+    List<AuditUpdateAction> auditUpdates = buildUpdateActions(rowsToUpdate);
 
     nbsTemplate.update(UPDATE_UN_SELECTED_ADDRESS_INACTIVE, params);
+    return auditUpdates;
   }
 
-  private void updateSelectedAddress(String survivingId, List<String> selectedLocators) {
-    Map<String, Object> params = new HashMap<>();
-    params.put("survivingId", survivingId);
-    params.put("selectedLocators", selectedLocators);
+  private List<Map<String, Object>> fetchUnselectedAddressesForAudit(String survivingId,
+      List<String> selectedLocators) {
+    return nbsTemplate.queryForList(FIND_UNSELECTED_ADDRESSES_FOR_AUDIT,
+        Map.of("survivingId", survivingId, "selectedLocators", selectedLocators));
+  }
+
+  private List<AuditUpdateAction> buildUpdateActions(List<Map<String, Object>> rows) {
+    return rows.stream()
+        .map(row -> new AuditUpdateAction(
+            Map.of("entity_uid", row.get("entity_uid"), "locator_uid", row.get("locator_uid")),//NOSONAR
+            Map.of("record_status_cd", row.get("record_status_cd"))
+        ))
+        .toList();
+  }
+
+  private List<AuditInsertAction> performSelectedAddressCopy(String survivingId, List<String> selectedLocators) {
+    Map<String, Object> params = Map.of(
+        "survivingId", survivingId,
+        "selectedLocators", selectedLocators
+    );
+
+    List<Map<String, Object>> insertedRows = nbsTemplate.queryForList(
+        FIND_SELECTED_LOCATORS_FOR_INSERT, params
+    );
+
+    List<AuditInsertAction> insertActions = buildInsertActions(survivingId, insertedRows);
 
     nbsTemplate.update(INSERT_NEW_LOCATORS, params);
+    return insertActions;
   }
 
-
+  private List<AuditInsertAction> buildInsertActions(String survivingId, List<Map<String, Object>> insertedRows) {
+    return insertedRows.stream()
+        .map(row -> new AuditInsertAction(Map.of(
+            "entity_uid", survivingId,
+            "locator_uid", row.get("locator_uid")
+        )))
+        .toList();
+  }
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonEthnicityMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonEthnicityMergeHandler.java
@@ -1,11 +1,15 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
-import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import gov.cdc.nbs.deduplication.merge.model.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 
 @Component
@@ -73,6 +77,20 @@ public class PersonEthnicityMergeHandler implements SectionMergeHandler {
         AND record_status_cd = 'ACTIVE'
       """;
 
+  static final String FIND_PREEXISTING_PERSON_ETHNIC_GROUPS_FOR_AUDIT = """
+      SELECT person_uid, ethnic_group_cd, record_status_cd
+      FROM person_ethnic_group
+      WHERE person_uid = :survivorId
+      """;
+
+
+  static final String FIND_SUPERSEDED_ETHNIC_GROUPS_FOR_AUDIT = """
+      SELECT  ethnic_group_cd
+      FROM person_ethnic_group
+      WHERE person_uid = :supersededId
+        AND record_status_cd = 'ACTIVE'
+      """;
+
 
   final NamedParameterJdbcTemplate nbsTemplate;
 
@@ -82,17 +100,55 @@ public class PersonEthnicityMergeHandler implements SectionMergeHandler {
 
   //Merge modifications have been applied to the person ethnicity
   @Override
-  public void handleMerge(String matchId, PatientMergeRequest request) {
-    mergePersonEthnicity(request.survivingRecord(), request.ethnicitySource());
+  public void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit patientMergeAudit) {
+    mergePersonEthnicity(request.survivingRecord(), request.ethnicitySource(), patientMergeAudit);
   }
 
-  private void mergePersonEthnicity(String survivorId, String ethnicitySourcePersonId) {
+  private void mergePersonEthnicity(String survivorId, String ethnicitySourcePersonId, PatientMergeAudit audit) {
     updatePersonEthnicityIndicator(survivorId, ethnicitySourcePersonId);
-    updatePreexistingEntriesToInactive(survivorId);
+    List<AuditUpdateAction> updateActions = performPreexistingEntriesInactivation(survivorId);
+    List<AuditInsertAction> insertActions = Collections.emptyList();
+
     if (!isEthnicityIndicatorNull(ethnicitySourcePersonId)) {
-      copySupersededEntriesToSurviving(survivorId, ethnicitySourcePersonId);
+      insertActions = performCopySupersededEntriesToSurviving(survivorId, ethnicitySourcePersonId);
     }
+
+    audit.getRelatedTableAudits().add(
+        new RelatedTableAudit("person_ethnic_group", updateActions, insertActions)
+    );
   }
+
+
+
+  private List<AuditInsertAction> performCopySupersededEntriesToSurviving(String survivorId, String supersededId) {
+    Map<String, Object> params = Map.of("supersededId", supersededId);
+
+    List<Map<String, Object>> rowsToInsert = nbsTemplate.queryForList(
+        FIND_SUPERSEDED_ETHNIC_GROUPS_FOR_AUDIT, params
+    );
+
+    List<AuditInsertAction> insertActions = buildAuditInsertActions(survivorId, rowsToInsert);
+
+    copySupersededEthnicGroupsToSurvivor(survivorId, supersededId);
+
+    return insertActions;
+  }
+
+  private List<AuditInsertAction> buildAuditInsertActions(String survivorId, List<Map<String, Object>> rows) {
+    return rows.stream()
+        .map(row -> new AuditInsertAction(
+            Map.of("person_uid", survivorId, "ethnic_group_cd", row.get("ethnic_group_cd"))//NOSONAR
+        ))
+        .toList();
+  }
+
+  private void copySupersededEthnicGroupsToSurvivor(String survivorId, String supersededId) {
+    nbsTemplate.update(
+        COPY_SUPERSEDED_ETHNIC_GROUPS_TO_SURVIVING,
+        Map.of("survivorId", survivorId, "supersededId", supersededId)//NOSONAR
+    );
+  }
+
 
 
   private void updatePersonEthnicityIndicator(String survivorId, String ethnicitySourcePersonId) {
@@ -102,11 +158,39 @@ public class PersonEthnicityMergeHandler implements SectionMergeHandler {
     nbsTemplate.update(UPDATE_PERSON_ETHNICITY_IND, parameters);
   }
 
-  private void updatePreexistingEntriesToInactive(String survivorId) {
-    MapSqlParameterSource parameters = new MapSqlParameterSource();
-    parameters.addValue("survivorId", survivorId);
-    nbsTemplate.update(UPDATE_PRE_EXISTING_ENTRIES_TO_INACTIVE, parameters);
+
+
+  private List<AuditUpdateAction> performPreexistingEntriesInactivation(String survivorId) {
+    Map<String, Object> params = Map.of("survivorId", survivorId);
+
+    List<Map<String, Object>> rowsToUpdate = nbsTemplate.queryForList(
+        FIND_PREEXISTING_PERSON_ETHNIC_GROUPS_FOR_AUDIT, params
+    );
+
+    List<AuditUpdateAction> updateActions = buildAuditUpdateActions(rowsToUpdate);
+
+    inactivatePreexistingEntries(survivorId);
+
+    return updateActions;
   }
+
+  private void inactivatePreexistingEntries(String survivorId) {
+    nbsTemplate.update(
+        UPDATE_PRE_EXISTING_ENTRIES_TO_INACTIVE,
+        Map.of("survivorId", survivorId)
+    );
+  }
+
+
+  private List<AuditUpdateAction> buildAuditUpdateActions(List<Map<String, Object>> rows) {
+    return rows.stream()
+        .map(row -> new AuditUpdateAction(
+            Map.of("person_uid", row.get("person_uid"), "ethnic_group_cd", row.get("ethnic_group_cd")),
+            Map.of("record_status_cd", row.get("record_status_cd"))
+        ))
+        .toList();
+  }
+
 
 
   private boolean isEthnicityIndicatorNull(String personUid) {
@@ -118,13 +202,6 @@ public class PersonEthnicityMergeHandler implements SectionMergeHandler {
     return ethnicityInd == null || ethnicityInd.isBlank();
   }
 
-  private void copySupersededEntriesToSurviving(String survivorId, String supersededId) {
-    MapSqlParameterSource parameters = new MapSqlParameterSource();
-    parameters.addValue("survivorId", survivorId);
-    parameters.addValue("supersededId", supersededId);
-
-    nbsTemplate.update(COPY_SUPERSEDED_ETHNIC_GROUPS_TO_SURVIVING, parameters);
-  }
 
 
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonGeneralInfoMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonGeneralInfoMergeHandler.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
@@ -139,7 +140,7 @@ public class PersonGeneralInfoMergeHandler implements SectionMergeHandler {
   }
 
   @Override
-  public void handleMerge(String matchId, PatientMergeRequest request) {
+  public void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit patientMergeAudit) {
     mergePersonGeneralInfo(request.survivingRecord(), request.generalInfoFieldSource());
   }
 

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandler.java
@@ -1,12 +1,13 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
-import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import gov.cdc.nbs.deduplication.merge.model.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Component
 @Order(3)
@@ -17,14 +18,16 @@ public class PersonNamesMergeHandler implements SectionMergeHandler {
   static final String UPDATE_ALL_PERSON_NAMES_INACTIVE = """
       UPDATE person_name
       SET record_status_cd = 'INACTIVE',
-          last_chg_time = GETDATE()
+          last_chg_time = GETDATE(),
+          last_chg_reason_cd='MERGE'
       WHERE person_uid = :personUid
       """;
 
   static final String UPDATE_SELECTED_EXCLUDED_NAMES_INACTIVE = """
       UPDATE person_name
       SET record_status_cd = 'INACTIVE',
-          last_chg_time = GETDATE()
+          last_chg_time = GETDATE(),
+          last_chg_reason_cd='MERGE'
       WHERE person_uid = :personUid
         AND person_name_seq NOT IN (:sequences)
       """;
@@ -81,72 +84,153 @@ public class PersonNamesMergeHandler implements SectionMergeHandler {
         AND person_name_seq = :oldSeq
       """;
 
+  private static final String FIND_PERSON_NAMES_FOR_INACTIVATION = """
+      SELECT person_uid, person_name_seq, record_status_cd
+      FROM person_name
+      WHERE person_uid = :personUid
+      """;
+
+  private static final String FIND_EXCLUDED_PERSON_NAMES_FOR_INACTIVATION = """
+      SELECT person_uid, person_name_seq, record_status_cd
+      FROM person_name
+      WHERE person_uid = :personUid
+        AND person_name_seq NOT IN (:sequences)
+      """;
+
+  private static final String FIND_SUPERSEDED_NAMES_FOR_AUDIT = """
+      SELECT person_uid, person_name_seq
+      FROM person_name
+      WHERE person_uid = :supersededUid
+        AND person_name_seq = :oldSeq
+      """;
+
   public PersonNamesMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
     this.nbsTemplate = nbsTemplate;
   }
 
   @Override
-  public void handleMerge(String matchId, PatientMergeRequest request) {
-    mergePersonNames(request.survivingRecord(), request.names());
+  public void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit patientMergeAudit) {
+    mergePersonNames(request.survivingRecord(), request.names(), patientMergeAudit);
   }
 
-  private void mergePersonNames(String survivorId, List<PatientMergeRequest.NameId> names) {
-    List<Integer> survivingNamesSequences = new ArrayList<>();
+  private void mergePersonNames(String survivorId, List<PatientMergeRequest.NameId> names, PatientMergeAudit audit) {
+    List<Integer> survivingSequences = new ArrayList<>();
     Map<String, List<Integer>> supersededNames = new HashMap<>();
-    categorizeNames(survivorId, names, survivingNamesSequences, supersededNames);
-    markUnselectedNamesInactive(survivorId, survivingNamesSequences);
-    updateSupersededNames(survivorId, supersededNames);
+
+    categorizeNames(survivorId, names, survivingSequences, supersededNames);
+
+    List<AuditUpdateAction> updateActions = performNameInactivation(survivorId, survivingSequences);
+    List<AuditInsertAction> insertActions = performNameCopyToSurvivor(survivorId, supersededNames);
+
+    audit.getRelatedTableAudits().add(new RelatedTableAudit("person_name", updateActions, insertActions));
   }
 
   private void categorizeNames(String survivorId, List<PatientMergeRequest.NameId> names,
       List<Integer> survivingSequences, Map<String, List<Integer>> supersededNames) {
-    for (PatientMergeRequest.NameId name : names) {
-      String personUid = name.personUid();
-      Integer seq = Integer.parseInt(name.sequence());
-
-      if (personUid.equals(survivorId)) {
-        survivingSequences.add(seq);
+    names.forEach(name -> {
+      if (name.personUid().equals(survivorId)) {
+        survivingSequences.add(Integer.parseInt(name.sequence()));
       } else {
-        supersededNames.computeIfAbsent(personUid, k -> new ArrayList<>()).add(seq);
+        supersededNames.computeIfAbsent(name.personUid(), k -> new ArrayList<>())
+            .add(Integer.parseInt(name.sequence()));
       }
-    }
+    });
   }
 
-  private void markUnselectedNamesInactive(String survivorId, List<Integer> selectedSequences) {
+  private List<AuditUpdateAction> performNameInactivation(String survivorId, List<Integer> selectedSequences) {
     String query =
         selectedSequences.isEmpty() ? UPDATE_ALL_PERSON_NAMES_INACTIVE : UPDATE_SELECTED_EXCLUDED_NAMES_INACTIVE;
     Map<String, Object> params = new HashMap<>();
-    params.put("personUid", survivorId);
+    params.put("personUid", survivorId);//NOSONAR
     if (!selectedSequences.isEmpty()) {
       params.put("sequences", selectedSequences);
     }
+
+
+    List<Map<String, Object>> rowsToUpdate = fetchRowsForInactivation(survivorId, selectedSequences);
+    List<AuditUpdateAction> auditUpdates = buildAuditUpdateActions(rowsToUpdate);
+
     nbsTemplate.update(query, params);
+    return auditUpdates;
   }
 
-  private void updateSupersededNames(String survivorId, Map<String, List<Integer>> supersededNames) {
-    for (Map.Entry<String, List<Integer>> entry : supersededNames.entrySet()) {
-      copySupersededNamesToSurviving(entry.getKey(), entry.getValue(), survivorId);
+  private List<Map<String, Object>> fetchRowsForInactivation(String survivorId, List<Integer> selectedSequences) {
+    if (selectedSequences.isEmpty()) {
+      return nbsTemplate.queryForList(
+          FIND_PERSON_NAMES_FOR_INACTIVATION,
+          Collections.singletonMap("personUid", survivorId)
+      );
     }
+
+    return nbsTemplate.queryForList(
+        FIND_EXCLUDED_PERSON_NAMES_FOR_INACTIVATION,
+        Map.of("personUid", survivorId, "sequences", selectedSequences)
+    );
   }
 
-  private void copySupersededNamesToSurviving(String supersededUid, List<Integer> sequences, String survivingId) {
-    int survivingMaxSeq = getMaxSequenceForPerson(survivingId);
+  private List<AuditUpdateAction> buildAuditUpdateActions(List<Map<String, Object>> rowsToUpdate) {
+    return rowsToUpdate.stream()
+        .map(row -> new AuditUpdateAction(
+            Map.of("person_uid", row.get("person_uid"), "person_name_seq", row.get("person_name_seq")),//NOSONAR
+            Map.of("record_status_cd", row.get("record_status_cd"))
+        ))
+        .toList();
+  }
 
-    for (Integer seq : sequences) {
-      int newSeq = ++survivingMaxSeq;
-      Map<String, Object> params = new HashMap<>();
-      params.put("supersededUid", supersededUid);
-      params.put("oldSeq", seq);
-      params.put("survivingId", survivingId);
-      params.put("newSeq", newSeq);
+  private List<AuditInsertAction> performNameCopyToSurvivor(String survivorId,
+      Map<String, List<Integer>> supersededNames) {
 
-      nbsTemplate.update(COPY_PERSON_NAME_TO_SURVIVING, params);
-    }
+    AtomicInteger maxSeq = new AtomicInteger(getMaxSequenceForPerson(survivorId));
+    List<AuditInsertAction> insertActions = new ArrayList<>();
+
+    supersededNames.forEach((supersededUid, sequences) -> {
+      for (Integer oldSeq : sequences) {
+        int newSeq = maxSeq.incrementAndGet();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("supersededUid", supersededUid);
+        params.put("oldSeq", oldSeq);
+
+        List<Map<String, Object>> rowsToInsert = nbsTemplate.queryForList(
+            FIND_SUPERSEDED_NAMES_FOR_AUDIT, params);
+
+
+        if (!rowsToInsert.isEmpty()) {
+          insertActions.add(buildAuditInsertAction(survivorId, newSeq));
+        }
+
+        copyPersonNameToSurvivor(survivorId, supersededUid, oldSeq, newSeq);
+      }
+    });
+
+    return insertActions;
+  }
+
+
+
+  private void copyPersonNameToSurvivor(String survivorId, String supersededUid, Integer oldSeq, int newSeq) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("survivingId", survivorId);
+    params.put("supersededUid", supersededUid);
+    params.put("oldSeq", oldSeq);
+    params.put("newSeq", newSeq);
+
+    nbsTemplate.update(COPY_PERSON_NAME_TO_SURVIVING, params);
+  }
+
+  private AuditInsertAction buildAuditInsertAction(String survivorId, int newSeq) {
+    return new AuditInsertAction(Map.of(
+        "person_uid", survivorId,
+        "person_name_seq", newSeq
+    ));
   }
 
   private int getMaxSequenceForPerson(String personUid) {
-    Map<String, Object> params = Collections.singletonMap("personUid", personUid);
-    Integer maxSequence = nbsTemplate.queryForObject(FIND_MAX_SEQUENCE_PERSON_NAME, params, Integer.class);
+    Integer maxSequence = nbsTemplate.queryForObject(
+        FIND_MAX_SEQUENCE_PERSON_NAME,
+        Collections.singletonMap("personUid", personUid),
+        Integer.class
+    );
     return maxSequence == null ? 0 : maxSequence;
   }
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandler.java
@@ -6,7 +6,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonRacesMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonRacesMergeHandler.java
@@ -1,6 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
-import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import gov.cdc.nbs.deduplication.merge.model.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -113,6 +113,23 @@ public class PersonRacesMergeHandler implements SectionMergeHandler {
       WHERE race_cd = :raceCd
       """;
 
+  private static final String FIND_PREEXISTING_PERSON_RACES_FOR_AUDIT = """
+      SELECT person_uid, race_cd, race_category_cd, record_status_cd
+      FROM person_race
+      WHERE person_uid = :survivorId
+        AND record_status_cd = 'ACTIVE'
+      """;
+
+  private static final String FIND_EXCLUDED_PERSON_RACES_FOR_AUDIT = """
+      SELECT person_uid, race_cd, race_category_cd, record_status_cd
+      FROM person_race
+      WHERE person_uid = :survivorId
+        AND record_status_cd = 'ACTIVE'
+        AND race_cd NOT IN (:survivingSelectedRaceCodes)
+      """;
+
+
+
   final NamedParameterJdbcTemplate nbsTemplate;
 
   public PersonRacesMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
@@ -121,19 +138,25 @@ public class PersonRacesMergeHandler implements SectionMergeHandler {
 
   //Merge modifications have been applied to the person races
   @Override
-  public void handleMerge(String matchId, PatientMergeRequest request) {
-    mergePersonRaces(request.survivingRecord(), request.races());
+  public void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit audit) {
+    mergePersonRaces(request.survivingRecord(), request.races(), audit);
   }
 
-  private void mergePersonRaces(String survivorId, List<PatientMergeRequest.RaceId> races) {
+  private void mergePersonRaces(String survivorId, List<PatientMergeRequest.RaceId> races, PatientMergeAudit audit) {
     List<String> survivingSelectedRaceCodes = new ArrayList<>();
     Map<String, List<String>> supersededRaceMap = new HashMap<>();
 
     categorizeRaces(survivorId, races, supersededRaceMap, survivingSelectedRaceCodes);
-    markUnselectedSurvivingRacesAsInactive(survivorId, survivingSelectedRaceCodes);
+    List<AuditUpdateAction> updateActions =
+        markUnselectedSurvivingRacesAsInactive(survivorId, survivingSelectedRaceCodes);
 
     List<String> survivingRaceCategories = getRaceCategoriesForSurvivor(survivorId);
-    processSupersededRaces(survivorId, supersededRaceMap, survivingRaceCategories);
+    List<AuditInsertAction> insertActions =
+        processSupersededRaces(survivorId, supersededRaceMap, survivingRaceCategories);
+
+    audit.getRelatedTableAudits().add(
+        new RelatedTableAudit("person_race", updateActions, insertActions)
+    );
   }
 
   private void categorizeRaces(String survivorId, List<PatientMergeRequest.RaceId> races,
@@ -151,36 +174,73 @@ public class PersonRacesMergeHandler implements SectionMergeHandler {
     }
   }
 
-  private void markUnselectedSurvivingRacesAsInactive(String survivorId, List<String> survivingSelectedRaceCodes) {
-    String query = survivingSelectedRaceCodes.isEmpty() ? UPDATE_ALL_SURVIVOR_RACES_INACTIVE :
-        UPDATE_SELECTED_EXCLUDED_RACES_INACTIVE;
+  private List<AuditUpdateAction> markUnselectedSurvivingRacesAsInactive(
+      String survivorId, List<String> survivingSelectedRaceCodes) {
 
-    Map<String, Object> params = new HashMap<>();
-    params.put("survivorId", survivorId);//NOSONAR
-    if (!survivingSelectedRaceCodes.isEmpty()) {
-      params.put("survivingSelectedRaceCodes", survivingSelectedRaceCodes);
-    }
-    nbsTemplate.update(query, params);
+    String query = survivingSelectedRaceCodes.isEmpty()
+        ? UPDATE_ALL_SURVIVOR_RACES_INACTIVE
+        : UPDATE_SELECTED_EXCLUDED_RACES_INACTIVE;
+
+    List<Map<String, Object>> rowsToUpdate = survivingSelectedRaceCodes.isEmpty()
+        ? nbsTemplate.queryForList(
+        FIND_PREEXISTING_PERSON_RACES_FOR_AUDIT,
+        Map.of("survivorId", survivorId)//NOSONAR
+    )
+        : nbsTemplate.queryForList(
+        FIND_EXCLUDED_PERSON_RACES_FOR_AUDIT,
+        Map.of("survivorId", survivorId, "survivingSelectedRaceCodes", survivingSelectedRaceCodes)
+    );
+
+    List<AuditUpdateAction> updateActions = buildAuditUpdateActions(survivorId, rowsToUpdate);
+
+    nbsTemplate.update(query, Map.of(
+        "survivorId", survivorId,
+        "survivingSelectedRaceCodes", survivingSelectedRaceCodes
+    ));
+
+    return updateActions;
   }
+
+  private List<AuditUpdateAction> buildAuditUpdateActions(String survivorId, List<Map<String, Object>> rows) {
+    return rows.stream()
+        .map(row -> new AuditUpdateAction(
+            Map.of(
+                "person_uid", survivorId,//NOSONAR
+                "race_cd", row.get("race_cd"),//NOSONAR
+                "race_category_cd", row.get("race_category_cd")//NOSONAR
+            ),
+            Map.of("record_status_cd", row.get("record_status_cd"))
+        ))
+        .toList();
+  }
+
 
   private List<String> getRaceCategoriesForSurvivor(String survivorId) {
     return nbsTemplate.queryForList(SELECT_ACTIVE_RACE_CATEGORIES,
         new MapSqlParameterSource("survivorId", survivorId), String.class);
   }
 
-  private void processSupersededRaces(String survivorId, Map<String, List<String>> supersededRaceMap,
+  private List<AuditInsertAction> processSupersededRaces(String survivorId,
+      Map<String, List<String>> supersededRaceMap,
       List<String> survivingRaceCategories) {
+    List<AuditInsertAction> auditInsertActionListAll = new ArrayList<>();
 
     for (Map.Entry<String, List<String>> entry : supersededRaceMap.entrySet()) {
       String supersededUid = entry.getKey();
       List<String> selectedRaceCodes = entry.getValue();
-      processRaceCodesForSuperseded(survivorId, supersededUid, selectedRaceCodes, survivingRaceCategories);
+      List<AuditInsertAction> auditInsertActionList =
+          processRaceCodesForSuperseded(survivorId, supersededUid, selectedRaceCodes, survivingRaceCategories);
+      auditInsertActionListAll.addAll(auditInsertActionList);
     }
+    return auditInsertActionListAll;
   }
 
-  private void processRaceCodesForSuperseded(String survivorId, String supersededUid, List<String> raceCodes,
-      List<String> survivingRaceCategories) {
 
+
+  private List<AuditInsertAction> processRaceCodesForSuperseded(String survivorId, String supersededUid,
+      List<String> raceCodes,
+      List<String> survivingRaceCategories) {
+    List<AuditInsertAction> auditInsertActionListAll = new ArrayList<>();
     Set<String> processedCategories = new HashSet<>();
 
     for (String raceCd : raceCodes) {
@@ -188,53 +248,119 @@ public class PersonRacesMergeHandler implements SectionMergeHandler {
       if (processedCategories.contains(raceCategoryCd))
         continue;
 
-      handleRaceCategory(survivorId, supersededUid, raceCategoryCd, survivingRaceCategories, raceCd);
+      List<AuditInsertAction> auditInsertActionList =
+          handleRaceCategory(survivorId, supersededUid, raceCategoryCd, survivingRaceCategories, raceCd);
+      auditInsertActionListAll.addAll(auditInsertActionList);
       processedCategories.add(raceCategoryCd);
     }
+    return auditInsertActionListAll;
   }
 
-  private void handleRaceCategory(String survivorId, String supersededUid, String raceCategoryCd,
+  private List<AuditInsertAction> handleRaceCategory(String survivorId, String supersededUid, String raceCategoryCd,
       List<String> survivingRaceCategories, String selectedRaceCd) {
 
+    List<AuditInsertAction> auditInsertActionList = new ArrayList<>();
+    AuditInsertAction auditInsertAction;
     if (survivingRaceCategories.contains(raceCategoryCd)) {
-      addNewRaceDetailToSurviving(survivorId, supersededUid, raceCategoryCd, selectedRaceCd);
+      auditInsertAction = addNewRaceDetailToSurviving(survivorId, supersededUid, raceCategoryCd, selectedRaceCd);
     } else {
-      copyRaceToSurviving(survivorId, supersededUid, raceCategoryCd);
-      copyRaceDetailToSurviving(survivorId, supersededUid, raceCategoryCd, selectedRaceCd);
+      auditInsertActionList = copyRaceToSurviving(survivorId, supersededUid, raceCategoryCd);
+      auditInsertAction = copyRaceDetailToSurviving(survivorId, supersededUid, raceCategoryCd, selectedRaceCd);
     }
+    auditInsertActionList.add(auditInsertAction);
+    return auditInsertActionList;
   }
 
-  private void addNewRaceDetailToSurviving(String survivorId, String supersededUid, String raceCategoryCd,
-      String selectedRaceCd) {
+  private AuditInsertAction addNewRaceDetailToSurviving(
+      String survivorId, String supersededUid, String raceCategoryCd, String selectedRaceCd) {
 
-    MapSqlParameterSource params = new MapSqlParameterSource();
-    params.addValue("survivorId", survivorId);
-    params.addValue("supersededUid", supersededUid);//NOSONAR
-    params.addValue("raceCategoryCd", raceCategoryCd);//NOSONAR
-    params.addValue("selectedRaceCd", selectedRaceCd);
+    String query = """
+        SELECT race_cd, race_category_cd
+        FROM person_race
+        WHERE person_uid = :supersededUid
+          AND race_category_cd = :raceCategoryCd
+          AND race_cd = :selectedRaceCd
+        """;
+
+    Map<String, Object> params = Map.of(
+        "survivorId", survivorId,
+        "supersededUid", supersededUid,//NOSONAR
+        "raceCategoryCd", raceCategoryCd,//NOSONAR
+        "selectedRaceCd", selectedRaceCd
+    );
+
+    Map<String, Object> rowToInsert = nbsTemplate.queryForMap(query, params);
 
     nbsTemplate.update(COPY_RACE_DETAIL_IF_NOT_EXISTS, params);
+
+    return new AuditInsertAction(Map.of(
+        "person_uid", survivorId,
+        "race_cd", rowToInsert.get("race_cd"),
+        "race_category_cd", rowToInsert.get("race_category_cd")
+    ));
   }
 
-  private void copyRaceToSurviving(String survivorId, String supersededUid, String raceCategoryCd) {
-    MapSqlParameterSource params = new MapSqlParameterSource();
-    params.addValue("survivorId", survivorId);
-    params.addValue("supersededUid", supersededUid);
-    params.addValue("raceCategoryCd", raceCategoryCd);
+
+  private List<AuditInsertAction> copyRaceToSurviving(
+      String survivorId, String supersededUid, String raceCategoryCd) {
+
+    String query = """
+        SELECT race_cd, race_category_cd
+        FROM person_race
+        WHERE person_uid = :supersededUid
+          AND race_category_cd = :raceCategoryCd
+        """;
+
+    Map<String, Object> params = Map.of(
+        "survivorId", survivorId,
+        "supersededUid", supersededUid,
+        "raceCategoryCd", raceCategoryCd
+    );
+
+    List<Map<String, Object>> rowsToInsert = nbsTemplate.queryForList(query, params);
 
     nbsTemplate.update(COPY_RACE_FROM_SUPERSEDED_TO_SURVIVOR, params);
+
+    return rowsToInsert.stream()
+        .map(row -> new AuditInsertAction(Map.of(
+            "person_uid", survivorId,
+            "race_cd", row.get("race_cd"),
+            "race_category_cd", row.get("race_category_cd")
+        )))
+        .toList();
   }
 
-  private void copyRaceDetailToSurviving(String survivorId, String supersededUid, String raceCategoryCd,
-      String selectedRaceCd) {
-    MapSqlParameterSource params = new MapSqlParameterSource();
-    params.addValue("survivorId", survivorId);
-    params.addValue("supersededUid", supersededUid);
-    params.addValue("raceCategoryCd", raceCategoryCd);
-    params.addValue("selectedRaceCd", selectedRaceCd);
+
+
+  private AuditInsertAction copyRaceDetailToSurviving(
+      String survivorId, String supersededUid, String raceCategoryCd, String selectedRaceCd) {
+
+    String query = """
+        SELECT race_cd, race_category_cd
+            FROM person_race
+            WHERE person_uid = :supersededUid
+              AND race_category_cd = :raceCategoryCd
+              AND race_cd = :selectedRaceCd
+        """;
+
+    Map<String, Object> params = Map.of(
+        "survivorId", survivorId,
+        "supersededUid", supersededUid,
+        "raceCategoryCd", raceCategoryCd,
+        "selectedRaceCd", selectedRaceCd
+    );
+
+    Map<String, Object> rowToInsert = nbsTemplate.queryForMap(query, params);
 
     nbsTemplate.update(COPY_RACE_DETAIL_FROM_SUPERSEDED_TO_SURVIVOR, params);
+
+    return new AuditInsertAction(Map.of(
+        "person_uid", survivorId,
+        "race_cd", rowToInsert.get("race_cd"),
+        "race_category_cd", rowToInsert.get("race_category_cd")
+    ));
   }
+
 
 
   private String getRaceCategoryCd(String raceCd) {

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandler.java
@@ -1,7 +1,9 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
 import gov.cdc.nbs.deduplication.constants.QueryConstants;
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -29,7 +31,7 @@ public class PersonTableMergeHandler implements SectionMergeHandler {
 
   //Modifications have been performed on the person table entries.
   @Override
-  public void handleMerge(String matchId, PatientMergeRequest request) {
+  public void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit patientMergeAudit) {
     String survivorId = request.survivingRecord();
     List<String> supersededUids = getSupersededRecords(matchId, survivorId);
     List<String> involvedPatients = new ArrayList<>();
@@ -42,6 +44,9 @@ public class PersonTableMergeHandler implements SectionMergeHandler {
     updateLastChangeTime(involvedPatients);
     markMergedRecordAsMerged(involvedPatients); // For involved patients(within current and other groups)
     saveSupersededPersonMergeDetails(survivorId, supersededUids);
+
+    patientMergeAudit.setSupersededIds(supersededUids);
+    patientMergeAudit.setMergeTimestamp(getCurrentUtcTimestamp());
   }
 
 
@@ -138,5 +143,6 @@ public class PersonTableMergeHandler implements SectionMergeHandler {
   public static Timestamp getCurrentUtcTimestamp() {
     return Timestamp.from(Instant.now());
   }
+
 
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/SectionMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/SectionMergeHandler.java
@@ -1,7 +1,8 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 
 public interface SectionMergeHandler {
-  void handleMerge(String matchId ,PatientMergeRequest request);
+  void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit patientMergeAudit);
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/AuditInsertAction.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/AuditInsertAction.java
@@ -1,0 +1,8 @@
+package gov.cdc.nbs.deduplication.merge.model;
+
+import java.util.Map;
+
+public record AuditInsertAction(
+    Map<String, Object> primaryKey
+) {
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/AuditUpdateAction.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/AuditUpdateAction.java
@@ -1,0 +1,9 @@
+package gov.cdc.nbs.deduplication.merge.model;
+
+import java.util.Map;
+
+public record AuditUpdateAction(
+    Map<String, Object> primaryKey,
+    Map<String, Object> previousValues
+) {
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/PatientMergeAudit.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/PatientMergeAudit.java
@@ -1,0 +1,18 @@
+package gov.cdc.nbs.deduplication.merge.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Getter
+@Setter
+public class PatientMergeAudit {
+  private Long id;
+  private String survivorId;
+  private List<String> supersededIds;
+  private Timestamp mergeTimestamp;
+  private List<RelatedTableAudit> relatedTableAudits;
+  private PatientMergeRequest patientMergeRequest;
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/RelatedTableAudit.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/RelatedTableAudit.java
@@ -1,0 +1,12 @@
+package gov.cdc.nbs.deduplication.merge.model;
+
+import java.util.List;
+
+public record RelatedTableAudit(
+    String tableName,
+    List<AuditUpdateAction> updates,
+    List<AuditInsertAction> inserts
+) {
+}
+
+

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/MergeServiceTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/MergeServiceTest.java
@@ -1,8 +1,10 @@
 package gov.cdc.nbs.deduplication.merge;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.cdc.nbs.deduplication.merge.handler.AdminCommentMergeHandler;
 import gov.cdc.nbs.deduplication.merge.handler.PersonTableMergeHandler;
 import gov.cdc.nbs.deduplication.merge.handler.SectionMergeHandler;
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import java.util.Arrays;
 import java.util.List;
@@ -27,11 +30,16 @@ class MergeServiceTest {
 
   private MergeService mergeService;
 
+  @Mock
+  private NamedParameterJdbcTemplate nbsTemplate;
+
+  @Mock
+  private ObjectMapper objectMapper;
 
   @BeforeEach
   void setUp() {
     List<SectionMergeHandler> handlers = Arrays.asList(personTableMergeHandler, adminCommentMergeHandler);
-    mergeService = new MergeService(handlers);
+    mergeService = new MergeService(nbsTemplate, handlers, objectMapper);
   }
 
   @Test
@@ -42,8 +50,8 @@ class MergeServiceTest {
     mergeService.performMerge(matchId, patientMergeRequest);
 
     InOrder inOrder = inOrder(personTableMergeHandler, adminCommentMergeHandler);
-    inOrder.verify(personTableMergeHandler).handleMerge(matchIdStr, patientMergeRequest);
-    inOrder.verify(adminCommentMergeHandler).handleMerge(matchIdStr, patientMergeRequest);
+    inOrder.verify(personTableMergeHandler).handleMerge(matchIdStr, patientMergeRequest,new PatientMergeAudit());
+    inOrder.verify(adminCommentMergeHandler).handleMerge(matchIdStr, patientMergeRequest,new PatientMergeAudit());
   }
 
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/AdminCommentMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/AdminCommentMergeHandlerTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
 import gov.cdc.nbs.deduplication.constants.QueryConstants;
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -35,7 +36,7 @@ class AdminCommentMergeHandlerTest {
     String matchId = "123";
     PatientMergeRequest request = getPatientMergeRequest();
 
-    handler.handleMerge(matchId, request);
+    handler.handleMerge(matchId, request, new PatientMergeAudit());
 
     verifyUpdateAdministrativeComments();
   }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandlerTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,7 @@ class PersonAddressMergeHandlerTest {
     String matchId = "match123";
     PatientMergeRequest request = getPatientMergeRequest(survivingId);
 
-    handler.handleMerge(matchId, request);
+    handler.handleMerge(matchId, request, new PatientMergeAudit());
 
     verify(nbsTemplate).update(eq(PersonAddressMergeHandler.UPDATE_UN_SELECTED_ADDRESS_INACTIVE),
         (Map<String, Object>) argThat(params -> {

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonBirthAndSexMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonBirthAndSexMergeHandlerTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,7 @@ class PersonBirthAndSexMergeHandlerTest {
     when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
     when(mockRequest.sexAndBirthFieldSource()).thenReturn(fieldSourceWithDiffIds);
 
-    handler.handleMerge("matchId", mockRequest);
+    handler.handleMerge("matchId", mockRequest, new PatientMergeAudit());
 
     verify(nbsTemplate, times(10)).update(anyString(), any(MapSqlParameterSource.class));
   }
@@ -66,7 +67,7 @@ class PersonBirthAndSexMergeHandlerTest {
     when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
     when(mockRequest.sexAndBirthFieldSource()).thenReturn(fieldSourceWithSameIds);
 
-    handler.handleMerge("matchId", mockRequest);
+    handler.handleMerge("matchId", mockRequest, new PatientMergeAudit());
 
     verify(nbsTemplate, never()).update(anyString(), any(MapSqlParameterSource.class));
   }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonEthnicityMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonEthnicityMergeHandlerTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,7 @@ class PersonEthnicityMergeHandlerTest {
         eq(String.class)))
         .thenReturn("2135-5");
 
-    handler.handleMerge("matchId", patientMergeRequest);
+    handler.handleMerge("matchId", patientMergeRequest, new PatientMergeAudit());
 
     verify(nbsTemplate).update(eq(PersonEthnicityMergeHandler.UPDATE_PERSON_ETHNICITY_IND),
         any(MapSqlParameterSource.class));

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonGeneralInfoMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonGeneralInfoMergeHandlerTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,7 @@ class PersonGeneralInfoMergeHandlerTest {
     when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
     when(mockRequest.generalInfoFieldSource()).thenReturn(fieldSourceWithDiffIds);
 
-    handler.handleMerge("matchId", mockRequest);
+    handler.handleMerge("matchId", mockRequest, new PatientMergeAudit());
 
     verify(nbsTemplate, times(10)).update(anyString(), any(MapSqlParameterSource.class));
   }
@@ -60,7 +61,7 @@ class PersonGeneralInfoMergeHandlerTest {
     when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
     when(mockRequest.generalInfoFieldSource()).thenReturn(fieldSourceWithSameIds);
 
-    handler.handleMerge("matchId", mockRequest);
+    handler.handleMerge("matchId", mockRequest, new PatientMergeAudit());
 
     verify(nbsTemplate, never()).update(anyString(), any(MapSqlParameterSource.class));
   }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonIdentificationsMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonIdentificationsMergeHandlerTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,7 +49,7 @@ class PersonIdentificationsMergeHandlerTest {
     PatientMergeRequest request = getPatientMergeRequest(identifications);
 
     mockMaxSequenceQueryToReturn(2);
-    handler.handleMerge(MATCH_ID, request);
+    handler.handleMerge(MATCH_ID, request, new PatientMergeAudit());
     verifyInactiveSurvivingIdentifications();
     verifySupersededIdentificationsMoves();
   }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonMortalityMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonMortalityMergeHandlerTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,7 @@ class PersonMortalityMergeHandlerTest {
     when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
     when(mockRequest.mortalityFieldSource()).thenReturn(fieldSourceWithDiffIds);
 
-    handler.handleMerge("matchId", mockRequest);
+    handler.handleMerge("matchId", mockRequest, new PatientMergeAudit());
 
     verify(nbsTemplate, times(5)).update(anyString(), any(MapSqlParameterSource.class));
   }
@@ -60,7 +61,7 @@ class PersonMortalityMergeHandlerTest {
     when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
     when(mockRequest.mortalityFieldSource()).thenReturn(fieldSourceWithSameIds);
 
-    handler.handleMerge("matchId", mockRequest);
+    handler.handleMerge("matchId", mockRequest, new PatientMergeAudit());
 
     verify(nbsTemplate, never()).update(anyString(), any(MapSqlParameterSource.class));
   }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonNamesMergeHandlerTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,7 @@ class PersonNamesMergeHandlerTest {
     PatientMergeRequest request = getPatientMergeRequest(names);
 
     mockMaxSequenceQueryToReturn(2);
-    handler.handleMerge(MATCH_ID, request);
+    handler.handleMerge(MATCH_ID, request, new PatientMergeAudit());
     verifyInactiveSurvivingNames();
     verifySupersededNameMoves();
   }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,7 +37,7 @@ class PersonPhoneEmailMergeHandlerTest {
     String matchId = "match123";
     PatientMergeRequest request = getPatientMergeRequest(survivingId);
 
-    handler.handleMerge(matchId, request);
+    handler.handleMerge(matchId, request, new PatientMergeAudit());
 
     verify(nbsTemplate).update(eq(PersonPhoneEmailMergeHandler.UPDATE_UN_SELECTED_PHONE_EMAIL_INACTIVE),
         (Map<String, Object>) argThat(params -> {

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonRacesMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonRacesMergeHandlerTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,7 +60,7 @@ class PersonRacesMergeHandlerTest {
     mockSurvivorRaceCategories(List.of(EXISTING_CATEGORY));
     mockRaceCategoryCd(EXISTING_CATEGORY);
 
-    handler.handleMerge("match-123", request);
+    handler.handleMerge("match-123", request, new PatientMergeAudit());
 
     verifyUnselectedSurvivingRacesMarkedInactive();
     verifyNewDetailedRaceInserted();
@@ -78,7 +79,7 @@ class PersonRacesMergeHandlerTest {
     mockSurvivorRaceCategories(Collections.singletonList(EXISTING_CATEGORY));
     mockRaceCategoryCd(NEW_CATEGORY);
 
-    handler.handleMerge("match-123", request);
+    handler.handleMerge("match-123", request, new PatientMergeAudit());
 
     verifyUnselectedSurvivingRacesMarkedInactive();
     verifyNewRaceCategoryCopiedToSurvivor();

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandlerTest.java
@@ -2,6 +2,7 @@ package gov.cdc.nbs.deduplication.merge.handler;
 
 
 import gov.cdc.nbs.deduplication.constants.QueryConstants;
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,7 +42,7 @@ class PersonTableMergeHandlerTest {
     mockFetchSupersededCandidatesToReturn("superseded1", "superseded2", "superseded3");
     mockFetchChildIdsOfSupersededToReturn("supersededChild1", "supersededChild2", "supersededChild3");
 
-    handler.handleMerge(matchId, request);
+    handler.handleMerge(matchId, request, new PatientMergeAudit());
 
     verifyCopyPersonToHistory();
     verifyIncrementPersonVersionNumber();


### PR DESCRIPTION
When patients are merged, the database should persist a detailed record of the merge to support a future un-merge process. This should include the patient (both superseded and surviving) data prior to the merge as well as the options the user selected as part of the merge process

## JIRA
https://cdc-nbs.atlassian.net/browse/CND-358