### PR TITLE
persist pre-merge patient data to support unmerge

### DIFF
--- a/containers/db/initialize/restore.d/04-create-deduplication-db.sql
+++ b/containers/db/initialize/restore.d/04-create-deduplication-db.sql
@@ -50,3 +50,13 @@ CREATE TABLE match_candidates (
   FOREIGN KEY (match_id) REFERENCES matches_requiring_review(id)
 );
 GO
+
+CREATE TABLE patient_merge_audit (
+    id BIGINT IDENTITY(1,1) PRIMARY KEY,
+    survivor_id VARCHAR(20) NOT NULL,
+    superseded_ids VARCHAR(200) NOT NULL,
+    merge_time DATETIME NOT NULL DEFAULT getdate(),
+    related_table_audits_json NVARCHAR(MAX) NOT NULL, -- Serialized PatientMergeAudit object
+	patient_merge_request_json NVARCHAR(MAX) NOT NULL -- Serialized PatientMergeRequest object
+);
+GO

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/MergeService.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/MergeService.java
@@ -3,6 +3,9 @@ package gov.cdc.nbs.deduplication.merge;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -23,32 +26,75 @@ public class MergeService {
       AND is_merge IS NULL;
       """;
 
+  static final String SAVE_PATIENT_MERGE_AUDIT = """
+          INSERT INTO patient_merge_audit (
+              survivor_id,
+              superseded_ids,
+              merge_time,
+              related_table_audits_json,
+              patient_merge_request_json
+          )
+          VALUES (
+              :survivorId,
+              :supersededIds,
+              GETDATE(),
+              :relatedAuditsJson,
+              :mergeRequestJson
+          )
+      """;
+
   private final List<SectionMergeHandler> handlers;
   private final JdbcClient deduplicationClient;
+  private final ObjectMapper objectMapper;
 
   public MergeService(
       final List<SectionMergeHandler> handlers,
-      final @Qualifier("deduplicationJdbcClient") JdbcClient deduplicationClient) {
+      final @Qualifier("deduplicationJdbcClient") JdbcClient deduplicationClient,
+      ObjectMapper objectMapper) {
     List<SectionMergeHandler> orderedHandlers = new ArrayList<>(handlers);
     AnnotationAwareOrderComparator.sort(orderedHandlers);
     this.handlers = orderedHandlers;
     this.deduplicationClient = deduplicationClient;
+    this.objectMapper = objectMapper;
   }
 
   @Transactional(transactionManager = "nbsTransactionManager", propagation = Propagation.REQUIRED)
-  public void performMerge(Long matchId, PatientMergeRequest request) {
+  public void performMerge(Long matchId, PatientMergeRequest request) throws JsonProcessingException {
     String matchIdStr = matchId.toString();
 
+    PatientMergeAudit patientMergeAudit = initPatientMergeAudit(request);
     for (SectionMergeHandler handler : handlers) {
-      handler.handleMerge(matchIdStr, request);
+      handler.handleMerge(matchIdStr, request, patientMergeAudit);
     }
 
     markPatientsMerged(matchId);
+    saveAuditToDatabase(patientMergeAudit);
   }
 
   private void markPatientsMerged(long matchId) {
     deduplicationClient.sql(MARK_PATIENTS_AS_MERGED)
         .param("matchId", matchId)
+        .update();
+  }
+
+  private PatientMergeAudit initPatientMergeAudit(PatientMergeRequest request) {
+    PatientMergeAudit patientMergeAudit = new PatientMergeAudit();
+    patientMergeAudit.setPatientMergeRequest(request);
+    patientMergeAudit.setSurvivorId(request.survivingRecord());
+    patientMergeAudit.setRelatedTableAudits(new ArrayList<>());
+    return patientMergeAudit;
+  }
+
+  private void saveAuditToDatabase(PatientMergeAudit audit) throws JsonProcessingException {
+    String relatedAuditsJson = objectMapper.writeValueAsString(audit.getRelatedTableAudits());
+    String mergeRequestJson = objectMapper.writeValueAsString(audit.getPatientMergeRequest());
+
+    deduplicationClient.sql(SAVE_PATIENT_MERGE_AUDIT)
+        .param("survivorId", audit.getSurvivorId())
+        .param("relatedAuditsJson", relatedAuditsJson)
+        .param("mergeRequestJson", mergeRequestJson)
+        .param("supersededIds",
+            String.join(",", audit.getSupersededIds() != null ? audit.getSupersededIds() : List.of()))
         .update();
   }
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/PatientMergeController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/PatientMergeController.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -74,7 +75,7 @@ public class PatientMergeController {
   @PostMapping("/{matchId}")
   public void mergePatients(
       @RequestBody PatientMergeRequest mergeRequest,
-      @PathVariable("matchId") Long matchId) {
+      @PathVariable("matchId") Long matchId) throws JsonProcessingException {
     mergeService.performMerge(matchId, mergeRequest);
   }
 

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/AdminCommentMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/AdminCommentMergeHandler.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -24,7 +25,7 @@ public class AdminCommentMergeHandler implements SectionMergeHandler {
   // Merge modifications have been applied to the Administrative Comments
   @Override
   @Transactional(transactionManager = "nbsTransactionManager", propagation = Propagation.MANDATORY)
-  public void handleMerge(String matchId, PatientMergeRequest request) {
+  public void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit patientMergeAudit) {
     String survivorId = request.survivingRecord();
     String adminCommentsSourcePersonUid = request.adminComments();
     updateAdministrativeComments(survivorId, adminCommentsSourcePersonUid);

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandler.java
@@ -1,17 +1,15 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import gov.cdc.nbs.deduplication.merge.model.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 
 @Component
 @Order(4)
@@ -90,42 +88,104 @@ public class PersonAddressMergeHandler implements SectionMergeHandler {
         AND class_cd = 'PST';
       """;
 
+  static final String FIND_SELECTED_LOCATORS_FOR_INSERT = """
+      SELECT locator_uid
+      FROM Entity_locator_participation
+      WHERE locator_uid IN (:selectedLocators)
+        AND entity_uid != :survivingId
+        AND use_cd NOT IN ('BIR', 'DTH')
+        AND class_cd = 'PST'
+      """;
+
+  static final String FIND_UNSELECTED_ADDRESSES_FOR_AUDIT = """
+      SELECT entity_uid, locator_uid, record_status_cd
+      FROM Entity_locator_participation
+      WHERE entity_uid = :survivingId
+        AND locator_uid NOT IN (:selectedLocators)
+        AND use_cd NOT IN ('BIR', 'DTH')
+        AND class_cd = 'PST'
+      """;
+
   public PersonAddressMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
     this.nbsTemplate = nbsTemplate;
   }
 
   @Override
   @Transactional(transactionManager = "nbsTransactionManager", propagation = Propagation.MANDATORY)
-  public void handleMerge(String matchId, PatientMergeRequest request) {
-    mergePersonAddress(request);
+  public void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit patientMergeAudit) {
+    mergePersonAddress(request, patientMergeAudit);
   }
 
-  private void mergePersonAddress(PatientMergeRequest request) {
+  private void mergePersonAddress(PatientMergeRequest request, PatientMergeAudit audit) {
     String survivingId = request.survivingRecord();
-    List<String> selectedLocatorIds = request.addresses().stream()
-        .map(PatientMergeRequest.AddressId::locatorId)
-        .toList();
+    List<String> selectedLocators = extractSelectedLocatorIds(request);
 
-    if (!selectedLocatorIds.isEmpty()) {
-      markUnselectedAddressInactive(survivingId, selectedLocatorIds);
-      updateSelectedAddress(survivingId, selectedLocatorIds);
+    if (!selectedLocators.isEmpty()) {
+      List<AuditUpdateAction> updateActions = performUnselectedAddressInactivation(survivingId, selectedLocators);
+      List<AuditInsertAction> insertActions = performSelectedAddressCopy(survivingId, selectedLocators);
+
+      audit.getRelatedTableAudits()
+          .add(new RelatedTableAudit("Entity_locator_participation", updateActions, insertActions));
     }
   }
 
-  private void markUnselectedAddressInactive(String survivingId, List<String> selectedLocators) {
-    Map<String, Object> params = new HashMap<>();
-    params.put("survivingId", survivingId);
-    params.put("selectedLocators", selectedLocators);
+  private List<String> extractSelectedLocatorIds(PatientMergeRequest request) {
+    return request.addresses().stream()
+        .map(PatientMergeRequest.AddressId::locatorId)
+        .toList();
+  }
+
+  private List<AuditUpdateAction> performUnselectedAddressInactivation(String survivingId,
+      List<String> selectedLocators) {
+    Map<String, Object> params = Map.of(
+        "survivingId", survivingId,//NOSONAR
+        "selectedLocators", selectedLocators//NOSONAR
+    );
+
+    List<Map<String, Object>> rowsToUpdate = fetchUnselectedAddressesForAudit(survivingId, selectedLocators);
+    List<AuditUpdateAction> auditUpdates = buildUpdateActions(rowsToUpdate);
 
     nbsTemplate.update(UPDATE_UN_SELECTED_ADDRESS_INACTIVE, params);
+    return auditUpdates;
   }
 
-  private void updateSelectedAddress(String survivingId, List<String> selectedLocators) {
-    Map<String, Object> params = new HashMap<>();
-    params.put("survivingId", survivingId);
-    params.put("selectedLocators", selectedLocators);
+  private List<Map<String, Object>> fetchUnselectedAddressesForAudit(String survivingId,
+      List<String> selectedLocators) {
+    return nbsTemplate.queryForList(FIND_UNSELECTED_ADDRESSES_FOR_AUDIT,
+        Map.of("survivingId", survivingId, "selectedLocators", selectedLocators));
+  }
+
+  private List<AuditUpdateAction> buildUpdateActions(List<Map<String, Object>> rows) {
+    return rows.stream()
+        .map(row -> new AuditUpdateAction(
+            Map.of("entity_uid", row.get("entity_uid"), "locator_uid", row.get("locator_uid")),//NOSONAR
+            Map.of("record_status_cd", row.get("record_status_cd"))
+        ))
+        .toList();
+  }
+
+  private List<AuditInsertAction> performSelectedAddressCopy(String survivingId, List<String> selectedLocators) {
+    Map<String, Object> params = Map.of(
+        "survivingId", survivingId,
+        "selectedLocators", selectedLocators
+    );
+
+    List<Map<String, Object>> insertedRows = nbsTemplate.queryForList(
+        FIND_SELECTED_LOCATORS_FOR_INSERT, params
+    );
+
+    List<AuditInsertAction> insertActions = buildInsertActions(survivingId, insertedRows);
 
     nbsTemplate.update(INSERT_NEW_LOCATORS, params);
+    return insertActions;
   }
 
+  private List<AuditInsertAction> buildInsertActions(String survivingId, List<Map<String, Object>> insertedRows) {
+    return insertedRows.stream()
+        .map(row -> new AuditInsertAction(Map.of(
+            "entity_uid", survivingId,
+            "locator_uid", row.get("locator_uid")
+        )))
+        .toList();
+  }
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonGeneralInfoMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonGeneralInfoMergeHandler.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -142,7 +143,7 @@ public class PersonGeneralInfoMergeHandler implements SectionMergeHandler {
 
   @Override
   @Transactional(transactionManager = "nbsTransactionManager", propagation = Propagation.MANDATORY)
-  public void handleMerge(String matchId, PatientMergeRequest request) {
+  public void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit patientMergeAudit) {
     mergePersonGeneralInfo(request.survivingRecord(), request.generalInfo());
   }
 

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonIdentificationsMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonIdentificationsMergeHandler.java
@@ -1,3 +1,5 @@
+
+
 package gov.cdc.nbs.deduplication.merge.handler;
 
 import java.util.ArrayList;
@@ -6,14 +8,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import gov.cdc.nbs.deduplication.merge.model.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 
 @Component
 @Order(6)
@@ -103,24 +104,56 @@ public class PersonIdentificationsMergeHandler implements SectionMergeHandler {
         AND entity_id_seq = :oldSeq
       """;
 
+  static final String FIND_ALL_IDENTIFICATIONS_FOR_AUDIT = """
+      SELECT entity_uid, entity_id_seq, record_status_cd
+      FROM Entity_id
+      WHERE entity_uid = :personUid
+      """;
+
+  static final String FIND_UNSELECTED_IDENTIFICATIONS_FOR_AUDIT = """
+      SELECT entity_uid, entity_id_seq, record_status_cd
+      FROM Entity_id
+      WHERE entity_uid = :personUid
+        AND entity_id_seq NOT IN (:sequences)
+      """;
+
+  static final String FIND_SUPERSEDED_IDENTIFICATIONS_FOR_AUDIT = """
+      SELECT entity_uid, entity_id_seq
+      FROM entity_id
+      WHERE entity_uid = :supersededUid
+        AND entity_id_seq = :seq
+      """;
+
   public PersonIdentificationsMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
     this.nbsTemplate = nbsTemplate;
   }
 
   @Override
   @Transactional(transactionManager = "nbsTransactionManager", propagation = Propagation.MANDATORY)
-  public void handleMerge(String matchId, PatientMergeRequest request) {
-    mergePersonIdentifications(request.survivingRecord(), request.identifications());
+  public void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit audit) {
+    mergePersonIdentifications(request.survivingRecord(), request.identifications(), audit);
   }
 
   private void mergePersonIdentifications(String survivorId,
-      List<PatientMergeRequest.IdentificationId> identifications) {
+      List<PatientMergeRequest.IdentificationId> identifications,
+      PatientMergeAudit audit) {
     List<Integer> survivingIdentificationsSequences = new ArrayList<>();
     Map<String, List<Integer>> supersededIdentifications = new HashMap<>();
-    categorizeIdentifications(survivorId, identifications, survivingIdentificationsSequences,
-        supersededIdentifications);
-    markUnselectedIdentificationsInactive(survivorId, survivingIdentificationsSequences);
-    updateSupersededIdentifications(survivorId, supersededIdentifications);
+
+    categorizeIdentifications(
+        survivorId, identifications, survivingIdentificationsSequences, supersededIdentifications
+    );
+
+    List<AuditUpdateAction> updateActions = markUnselectedIdentificationsInactive(
+        survivorId, survivingIdentificationsSequences
+    );
+    List<AuditInsertAction> insertActions = updateSupersededIdentifications(
+        survivorId, supersededIdentifications
+    );
+
+    audit.getRelatedTableAudits().add(
+        new RelatedTableAudit("Entity_id", updateActions, insertActions)
+    );
   }
 
   private void categorizeIdentifications(String survivorId, List<PatientMergeRequest.IdentificationId> identifications,
@@ -137,38 +170,99 @@ public class PersonIdentificationsMergeHandler implements SectionMergeHandler {
     }
   }
 
-  private void markUnselectedIdentificationsInactive(String survivorId, List<Integer> selectedSequences) {
+  private List<AuditUpdateAction> markUnselectedIdentificationsInactive(String survivorId,
+      List<Integer> selectedSequences) {
     String query = selectedSequences.isEmpty() ? UPDATE_ALL_PERSON_IDENTIFICATION_INACTIVE
         : UPDATE_SELECTED_EXCLUDED_IDENTIFICATION_INACTIVE;
+
     Map<String, Object> params = new HashMap<>();
     params.put("personUid", survivorId);
-    if (!selectedSequences.isEmpty()) {
+
+    List<Map<String, Object>> rowsToUpdate;
+
+    if (selectedSequences.isEmpty()) {
+      rowsToUpdate = nbsTemplate.queryForList(
+          FIND_ALL_IDENTIFICATIONS_FOR_AUDIT, params
+      );
+    } else {
       params.put("sequences", selectedSequences);
+      rowsToUpdate = nbsTemplate.queryForList(
+          FIND_UNSELECTED_IDENTIFICATIONS_FOR_AUDIT, params
+      );
     }
+
+    List<AuditUpdateAction> auditUpdates = buildAuditUpdateActions(rowsToUpdate);
+
     nbsTemplate.update(query, params);
+    return auditUpdates;
   }
 
-  private void updateSupersededIdentifications(String survivorId,
-      Map<String, List<Integer>> supersededIdentifications) {
+  private List<AuditUpdateAction> buildAuditUpdateActions(List<Map<String, Object>> rows) {
+    return rows.stream()
+        .map(row -> new AuditUpdateAction(
+            Map.of("entity_uid", row.get("entity_uid"), "entity_id_seq", row.get("entity_id_seq")),//NOSONAR
+            Map.of("record_status_cd", row.get("record_status_cd"))
+        ))
+        .toList();
+  }
+
+
+  private List<AuditInsertAction> updateSupersededIdentifications(
+      String survivorId, Map<String, List<Integer>> supersededIdentifications
+  ) {
+    List<AuditInsertAction> insertActions = new ArrayList<>();
+
     for (Map.Entry<String, List<Integer>> entry : supersededIdentifications.entrySet()) {
-      copySupersededIdentificationsToSurviving(entry.getKey(), entry.getValue(), survivorId);
+      String supersededUid = entry.getKey();
+      List<Integer> sequences = entry.getValue();
+      insertActions.addAll(copySupersededIdentificationsToSurviving(supersededUid, sequences, survivorId));
     }
+
+    return insertActions;
   }
 
-  private void copySupersededIdentificationsToSurviving(String supersededUid, List<Integer> sequences,
-      String survivingId) {
+  private List<AuditInsertAction> copySupersededIdentificationsToSurviving(
+      String supersededUid, List<Integer> sequences, String survivingId) {
+
     int survivingMaxSeq = getMaxSequenceForPerson(survivingId);
+    List<AuditInsertAction> insertActions = new ArrayList<>();
 
-    for (Integer seq : sequences) {
+    for (Integer oldSeq : sequences) {
       int newSeq = ++survivingMaxSeq;
-      Map<String, Object> params = new HashMap<>();
-      params.put("supersededUid", supersededUid);
-      params.put("oldSeq", seq);
-      params.put("survivingId", survivingId);
-      params.put("newSeq", newSeq);
 
-      nbsTemplate.update(COPY_ENTITY_ID_TO_SURVIVING, params);
+      Map<String, Object> params = Map.of(
+          "supersededUid", supersededUid,
+          "seq", oldSeq
+      );
+
+      List<Map<String, Object>> rowsToInsert = nbsTemplate.queryForList(
+          FIND_SUPERSEDED_IDENTIFICATIONS_FOR_AUDIT, params);
+
+      if (!rowsToInsert.isEmpty()) {
+        insertActions.add(buildAuditInsertAction(survivingId, newSeq));
+      }
+
+      copyIdentificationToSurvivor(supersededUid, oldSeq, survivingId, newSeq);
     }
+
+    return insertActions;
+  }
+
+  private void copyIdentificationToSurvivor(String supersededUid, Integer oldSeq, String survivingId, int newSeq) {
+    Map<String, Object> params = new HashMap<>();
+    params.put("supersededUid", supersededUid);
+    params.put("oldSeq", oldSeq);
+    params.put("survivingId", survivingId);
+    params.put("newSeq", newSeq);
+
+    nbsTemplate.update(COPY_ENTITY_ID_TO_SURVIVING, params);
+  }
+
+  private AuditInsertAction buildAuditInsertAction(String survivingId, int newSeq) {
+    return new AuditInsertAction(Map.of(
+        "entity_uid", survivingId,
+        "entity_id_seq", newSeq
+    ));
   }
 
   private int getMaxSequenceForPerson(String personUid) {
@@ -177,3 +271,12 @@ public class PersonIdentificationsMergeHandler implements SectionMergeHandler {
     return maxSequence == null ? 0 : maxSequence;
   }
 }
+
+
+
+
+
+
+
+
+

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandler.java
@@ -1,17 +1,15 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import gov.cdc.nbs.deduplication.merge.model.*;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-
-import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 
 @Component
 @Order(5)
@@ -88,42 +86,104 @@ public class PersonPhoneEmailMergeHandler implements SectionMergeHandler {
         AND class_cd = 'TELE';
       """;
 
+  static final String FIND_UNSELECTED_PHONE_EMAILS_FOR_AUDIT = """
+      SELECT entity_uid, locator_uid, record_status_cd
+      FROM Entity_locator_participation
+      WHERE entity_uid = :survivingId
+        AND locator_uid NOT IN (:selectedLocators)
+        AND class_cd = 'TELE'
+      """;
+
+  static final String FIND_SELECTED_PHONE_EMAIL_LOCATORS_FOR_INSERT = """
+      SELECT locator_uid
+      FROM Entity_locator_participation
+      WHERE locator_uid IN (:selectedLocators)
+        AND entity_uid != :survivingId
+        AND class_cd = 'TELE'
+      """;
+
   public PersonPhoneEmailMergeHandler(@Qualifier("nbsNamedTemplate") NamedParameterJdbcTemplate nbsTemplate) {
     this.nbsTemplate = nbsTemplate;
   }
 
   @Override
   @Transactional(transactionManager = "nbsTransactionManager", propagation = Propagation.MANDATORY)
-  public void handleMerge(String matchId, PatientMergeRequest request) {
-    mergePersonPhoneEmail(request);
+  public void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit patientMergeAudit) {
+    mergePersonPhoneEmail(request, patientMergeAudit);
   }
 
-  private void mergePersonPhoneEmail(PatientMergeRequest request) {
+  private void mergePersonPhoneEmail(PatientMergeRequest request, PatientMergeAudit audit) {
     String survivingId = request.survivingRecord();
-    List<String> selectedLocatorIds = request.phoneEmails().stream()
-        .map(PatientMergeRequest.PhoneEmailId::locatorId)
-        .toList();
+    List<String> selectedLocators = extractSelectedLocatorIds(request);
 
-    if (!selectedLocatorIds.isEmpty()) {
-      markUnselectedPhoneEmailInactive(survivingId, selectedLocatorIds);
-      updateSelectedPhoneEmail(survivingId, selectedLocatorIds);
+    if (!selectedLocators.isEmpty()) {
+      List<AuditUpdateAction> updateActions = performUnselectedPhoneEmailInactivation(survivingId, selectedLocators);
+      List<AuditInsertAction> insertActions = performSelectedPhoneEmailCopy(survivingId, selectedLocators);
+
+      audit.getRelatedTableAudits()
+          .add(new RelatedTableAudit("Entity_locator_participation", updateActions, insertActions));
     }
   }
 
-  private void markUnselectedPhoneEmailInactive(String survivingId, List<String> selectedLocators) {
-    Map<String, Object> params = new HashMap<>();
-    params.put("survivingId", survivingId);
-    params.put("selectedLocators", selectedLocators);
+  private List<String> extractSelectedLocatorIds(PatientMergeRequest request) {
+    return request.phoneEmails().stream()
+        .map(PatientMergeRequest.PhoneEmailId::locatorId)
+        .toList();
+  }
+
+  private List<AuditUpdateAction> performUnselectedPhoneEmailInactivation(String survivingId,
+      List<String> selectedLocators) {
+    Map<String, Object> params = Map.of(
+        "survivingId", survivingId, //NOSONAR
+        "selectedLocators", selectedLocators  //NOSONAR
+    );
+
+    List<Map<String, Object>> rowsToUpdate = fetchUnselectedPhoneEmailsForAudit(survivingId, selectedLocators);
+    List<AuditUpdateAction> auditUpdates = buildUpdateActions(rowsToUpdate);
 
     nbsTemplate.update(UPDATE_UN_SELECTED_PHONE_EMAIL_INACTIVE, params);
+    return auditUpdates;
   }
 
-  private void updateSelectedPhoneEmail(String survivingId, List<String> selectedLocators) {
-    Map<String, Object> params = new HashMap<>();
-    params.put("survivingId", survivingId);
-    params.put("selectedLocators", selectedLocators);
+  private List<Map<String, Object>> fetchUnselectedPhoneEmailsForAudit(String survivingId,
+      List<String> selectedLocators) {
+    return nbsTemplate.queryForList(
+        FIND_UNSELECTED_PHONE_EMAILS_FOR_AUDIT,
+        Map.of("survivingId", survivingId, "selectedLocators", selectedLocators)
+    );
+  }
+
+  private List<AuditUpdateAction> buildUpdateActions(List<Map<String, Object>> rows) {
+    return rows.stream()
+        .map(row -> new AuditUpdateAction(
+            Map.of("entity_uid", row.get("entity_uid"), "locator_uid", row.get("locator_uid")),//NOSONAR
+            Map.of("record_status_cd", row.get("record_status_cd"))
+        ))
+        .toList();
+  }
+
+  private List<AuditInsertAction> performSelectedPhoneEmailCopy(String survivingId, List<String> selectedLocators) {
+    Map<String, Object> params = Map.of(
+        "survivingId", survivingId,
+        "selectedLocators", selectedLocators
+    );
+
+    List<Map<String, Object>> insertedRows = nbsTemplate.queryForList(
+        FIND_SELECTED_PHONE_EMAIL_LOCATORS_FOR_INSERT, params
+    );
+
+    List<AuditInsertAction> insertActions = buildInsertActions(survivingId, insertedRows);
 
     nbsTemplate.update(INSERT_NEW_PHONE_EMAIL_LOCATORS, params);
+    return insertActions;
   }
 
+  private List<AuditInsertAction> buildInsertActions(String survivingId, List<Map<String, Object>> insertedRows) {
+    return insertedRows.stream()
+        .map(row -> new AuditInsertAction(Map.of(
+            "entity_uid", survivingId,
+            "locator_uid", row.get("locator_uid")
+        )))
+        .toList();
+  }
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/SectionMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/SectionMergeHandler.java
@@ -1,7 +1,8 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 
 public interface SectionMergeHandler {
-  void handleMerge(String matchId, PatientMergeRequest request);
+  void handleMerge(String matchId, PatientMergeRequest request, PatientMergeAudit patientMergeAudit);
 }

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/AuditInsertAction.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/AuditInsertAction.java
@@ -1,0 +1,8 @@
+package gov.cdc.nbs.deduplication.merge.model;
+
+import java.util.Map;
+
+public record AuditInsertAction(
+    Map<String, Object> primaryKey
+) {
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/AuditUpdateAction.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/AuditUpdateAction.java
@@ -1,0 +1,9 @@
+package gov.cdc.nbs.deduplication.merge.model;
+
+import java.util.Map;
+
+public record AuditUpdateAction(
+    Map<String, Object> primaryKey,
+    Map<String, Object> previousValues
+) {
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/PatientMergeAudit.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/PatientMergeAudit.java
@@ -1,0 +1,24 @@
+package gov.cdc.nbs.deduplication.merge.model;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PatientMergeAudit {
+  public PatientMergeAudit(List<RelatedTableAudit> relatedTableAudits) {
+    this.relatedTableAudits = relatedTableAudits;
+  }
+
+  private Long id;
+  private String survivorId;
+  private List<String> supersededIds;
+  private Timestamp mergeTimestamp;
+  private List<RelatedTableAudit> relatedTableAudits;
+  private PatientMergeRequest patientMergeRequest;
+}

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/RelatedTableAudit.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/model/RelatedTableAudit.java
@@ -1,0 +1,12 @@
+package gov.cdc.nbs.deduplication.merge.model;
+
+import java.util.List;
+
+public record RelatedTableAudit(
+    String tableName,
+    List<AuditUpdateAction> updates,
+    List<AuditInsertAction> inserts
+) {
+}
+
+

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/MergeServiceTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/MergeServiceTest.java
@@ -3,6 +3,7 @@ package gov.cdc.nbs.deduplication.merge;
 import gov.cdc.nbs.deduplication.merge.handler.AdminCommentMergeHandler;
 import gov.cdc.nbs.deduplication.merge.handler.PersonTableMergeHandler;
 import gov.cdc.nbs.deduplication.merge.handler.SectionMergeHandler;
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,8 @@ import org.springframework.jdbc.core.simple.JdbcClient.StatementSpec;
 
 import java.util.Arrays;
 import java.util.List;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.mockito.Mockito.*;
 
@@ -31,28 +34,61 @@ class MergeServiceTest {
   @Mock
   private JdbcClient deduplicationClient;
 
+  @Mock
+  private ObjectMapper objectMapper;
+
   private MergeService mergeService;
 
   @BeforeEach
   void setUp() {
     List<SectionMergeHandler> handlers = Arrays.asList(personTableMergeHandler, adminCommentMergeHandler);
     StatementSpec mockStatementSpec = Mockito.mock(StatementSpec.class);
+
     when(deduplicationClient.sql(MergeService.MARK_PATIENTS_AS_MERGED)).thenReturn(mockStatementSpec);
     when(mockStatementSpec.param("matchId", 123L)).thenReturn(mockStatementSpec);
-    mergeService = new MergeService(handlers, deduplicationClient);
+    when(mockStatementSpec.update()).thenReturn(1); // simulate update success
+
+    StatementSpec auditStatementSpec = Mockito.mock(StatementSpec.class);
+    when(deduplicationClient.sql(MergeService.SAVE_PATIENT_MERGE_AUDIT)).thenReturn(auditStatementSpec);
+    when(auditStatementSpec.param(anyString(), any())).thenReturn(auditStatementSpec);
+    when(auditStatementSpec.update()).thenReturn(1); // simulate audit insert success
+
+    mergeService = new MergeService(handlers, deduplicationClient, objectMapper);
   }
 
   @Test
-  void testPerformMerge_CallsAllHandlersInOrder() {
+  void testPerformMerge_CallsAllHandlersInOrder_AndSavesAudit() throws Exception {
+    // Arrange
     long matchId = 123L;
     String matchIdStr = "123";
-    PatientMergeRequest patientMergeRequest = mock(PatientMergeRequest.class);
-    mergeService.performMerge(matchId, patientMergeRequest);
 
+    PatientMergeRequest request = mock(PatientMergeRequest.class);
+    when(request.survivingRecord()).thenReturn("999");
+
+
+
+    String relatedAuditsJson = "[{\"table\":\"person\",\"action\":\"update\"}]";
+    String mergeRequestJson = "{\"survivingRecord\":\"999\"}";
+
+    // Mock objectMapper serialization
+    when(objectMapper.writeValueAsString(any())).thenReturn(relatedAuditsJson, mergeRequestJson);
+
+    // Act
+    mergeService.performMerge(matchId, request);
+
+    // Assert: Verify handlers are called in order
     InOrder inOrder = inOrder(personTableMergeHandler, adminCommentMergeHandler, deduplicationClient);
-    inOrder.verify(personTableMergeHandler).handleMerge(matchIdStr, patientMergeRequest);
-    inOrder.verify(adminCommentMergeHandler).handleMerge(matchIdStr, patientMergeRequest);
-    inOrder.verify(deduplicationClient).sql(MergeService.MARK_PATIENTS_AS_MERGED);
-  }
 
+    inOrder.verify(personTableMergeHandler).handleMerge(eq(matchIdStr), eq(request), any(PatientMergeAudit.class));
+    inOrder.verify(adminCommentMergeHandler).handleMerge(eq(matchIdStr), eq(request), any(PatientMergeAudit.class));
+
+    // Assert: Verify markPatientsMerged is called
+    inOrder.verify(deduplicationClient).sql(MergeService.MARK_PATIENTS_AS_MERGED);
+
+    // Assert: Verify audit is saved
+    inOrder.verify(deduplicationClient).sql(MergeService.SAVE_PATIENT_MERGE_AUDIT);
+
+    // Assert: Verify ObjectMapper was used to serialize
+    verify(objectMapper, times(2)).writeValueAsString(any());
+  }
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/AdminCommentMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/AdminCommentMergeHandlerTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
 import gov.cdc.nbs.deduplication.constants.QueryConstants;
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -24,6 +25,9 @@ class AdminCommentMergeHandlerTest {
 
   private AdminCommentMergeHandler handler;
 
+  @Mock
+  private PatientMergeAudit patientMergeAudit;
+
 
   @BeforeEach
   void setUp() {
@@ -35,7 +39,7 @@ class AdminCommentMergeHandlerTest {
     String matchId = "123";
     PatientMergeRequest request = getPatientMergeRequest();
 
-    handler.handleMerge(matchId, request);
+    handler.handleMerge(matchId, request, patientMergeAudit);
 
     verifyUpdateAdministrativeComments();
   }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonAddressMergeHandlerTest.java
@@ -1,17 +1,23 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import gov.cdc.nbs.deduplication.merge.model.RelatedTableAudit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -19,9 +25,14 @@ import static org.mockito.Mockito.*;
 class PersonAddressMergeHandlerTest {
 
   @Mock
-  private NamedParameterJdbcTemplate nbsTemplate;
+  NamedParameterJdbcTemplate nbsTemplate;
 
-  private PersonAddressMergeHandler handler;
+  PersonAddressMergeHandler handler;
+
+  static final String SURVIVING_PERSON_UID = "survivor123";
+  static final String SUPERSEDED_LOCATOR_ID_1 = "locator123";
+  static final String SUPERSEDED_LOCATOR_ID_2 = "locator456";
+  static final String MATCH_ID = "match-001";
 
   @BeforeEach
   void setUp() {
@@ -29,38 +40,87 @@ class PersonAddressMergeHandlerTest {
   }
 
   @Test
-  @SuppressWarnings("unchecked")
-  void handleMerge_shouldPerformAllPersonAddressesRelatedDatabaseOperations() {
-    String survivingId = "survivorId1";
-    String matchId = "match123";
-    PatientMergeRequest request = getPatientMergeRequest(survivingId);
+  void handleMerge_shouldPerformAllPersonAddressRelatedDatabaseOperations() {
+    PatientMergeRequest request = getPatientMergeRequest();
+    PatientMergeAudit audit = new PatientMergeAudit(new ArrayList<>());
 
-    handler.handleMerge(matchId, request);
+    mockAuditForUnselectedAddresses();
+    mockSelectedLocatorsForInsert();
 
-    verify(nbsTemplate).update(eq(PersonAddressMergeHandler.UPDATE_UN_SELECTED_ADDRESS_INACTIVE),
-        (Map<String, Object>) argThat(params -> {
-          Map<String, Object> paramMap = (Map<String, Object>) params;
-          return survivingId.equals(paramMap.get("survivingId")) &&
-              List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
-        }));
+    handler.handleMerge(MATCH_ID, request, audit);
 
-    verify(nbsTemplate).update(eq(PersonAddressMergeHandler.INSERT_NEW_LOCATORS),
-        (Map<String, Object>) argThat(params -> {
-          Map<String, Object> paramMap = (Map<String, Object>) params;
-          return survivingId.equals(paramMap.get("survivingId")) &&
-              List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
-        }));
+    verifyInactiveUnselectedAddresses();
+    verifySelectedAddressInsertions();
 
+    verifyAuditData(audit);
   }
 
-  private PatientMergeRequest getPatientMergeRequest(String survivingId) {
+  private PatientMergeRequest getPatientMergeRequest() {
     List<PatientMergeRequest.AddressId> addressIds = Arrays.asList(
-        new PatientMergeRequest.AddressId("locator1"),
-        new PatientMergeRequest.AddressId("locator2")
+        new PatientMergeRequest.AddressId(SUPERSEDED_LOCATOR_ID_1),
+        new PatientMergeRequest.AddressId(SUPERSEDED_LOCATOR_ID_2)
     );
-    return new PatientMergeRequest(survivingId, null,
+    return new PatientMergeRequest(SURVIVING_PERSON_UID, null,
         null, addressIds, null, null, null, null, null, null, null);
   }
 
+  @SuppressWarnings("unchecked")
+  private void mockAuditForUnselectedAddresses() {
+    when(nbsTemplate.queryForList(
+        eq(PersonAddressMergeHandler.FIND_UNSELECTED_ADDRESSES_FOR_AUDIT),
+        any(Map.class)
+    )).thenReturn(List.of(
+        Map.of(
+            "entity_uid", SURVIVING_PERSON_UID,
+            "locator_uid", "locator789",
+            "record_status_cd", "ACTIVE"
+        )
+    ));
+  }
 
+  @SuppressWarnings("unchecked")
+  private void mockSelectedLocatorsForInsert() {
+    when(nbsTemplate.queryForList(
+        eq(PersonAddressMergeHandler.FIND_SELECTED_LOCATORS_FOR_INSERT),
+        any(Map.class)
+    )).thenReturn(List.of(
+        Map.of("locator_uid", SUPERSEDED_LOCATOR_ID_1),
+        Map.of("locator_uid", SUPERSEDED_LOCATOR_ID_2)
+    ));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void verifyInactiveUnselectedAddresses() {
+    ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(nbsTemplate).update(
+        eq(PersonAddressMergeHandler.UPDATE_UN_SELECTED_ADDRESS_INACTIVE),
+        paramsCaptor.capture()
+    );
+
+    Map<String, Object> params = paramsCaptor.getValue();
+    assertEquals(SURVIVING_PERSON_UID, params.get("survivingId"));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void verifySelectedAddressInsertions() {
+    ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(nbsTemplate).update(
+        eq(PersonAddressMergeHandler.INSERT_NEW_LOCATORS),
+        paramsCaptor.capture()
+    );
+
+    Map<String, Object> params = paramsCaptor.getValue();
+    assertEquals(SURVIVING_PERSON_UID, params.get("survivingId"));
+    assertTrue(((List<String>) params.get("selectedLocators")).contains(SUPERSEDED_LOCATOR_ID_1));
+  }
+
+  private void verifyAuditData(PatientMergeAudit audit) {
+    assertEquals(1, audit.getRelatedTableAudits().size());
+
+    RelatedTableAudit tableAudit = audit.getRelatedTableAudits().getFirst();
+    assertEquals("Entity_locator_participation", tableAudit.tableName());
+
+    assertEquals(1, tableAudit.updates().size());
+    assertEquals(2, tableAudit.inserts().size());
+  }
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonGeneralInfoMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonGeneralInfoMergeHandlerTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,9 @@ class PersonGeneralInfoMergeHandlerTest {
   private PatientMergeRequest.GeneralInfoFieldSource fieldSourceWithDiffIds;
   private PatientMergeRequest.GeneralInfoFieldSource fieldSourceWithSameIds;
 
+  @Mock
+  private PatientMergeAudit patientMergeAudit;
+
   @BeforeEach
   void setUp() {
     handler = new PersonGeneralInfoMergeHandler(nbsTemplate);
@@ -46,7 +50,7 @@ class PersonGeneralInfoMergeHandlerTest {
     when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
     when(mockRequest.generalInfo()).thenReturn(fieldSourceWithDiffIds);
 
-    handler.handleMerge("matchId", mockRequest);
+    handler.handleMerge("matchId", mockRequest, patientMergeAudit);
 
     verify(nbsTemplate, times(10)).update(anyString(), any(MapSqlParameterSource.class));
   }
@@ -56,7 +60,7 @@ class PersonGeneralInfoMergeHandlerTest {
     when(mockRequest.survivingRecord()).thenReturn(SURVIVOR_ID);
     when(mockRequest.generalInfo()).thenReturn(fieldSourceWithSameIds);
 
-    handler.handleMerge("matchId", mockRequest);
+    handler.handleMerge("matchId", mockRequest, patientMergeAudit);
 
     verify(nbsTemplate, never()).update(anyString(), any(MapSqlParameterSource.class));
   }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonPhoneEmailMergeHandlerTest.java
@@ -1,20 +1,24 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
+import gov.cdc.nbs.deduplication.merge.model.RelatedTableAudit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.argThat;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class PersonPhoneEmailMergeHandlerTest {
@@ -24,45 +28,109 @@ class PersonPhoneEmailMergeHandlerTest {
 
   private PersonPhoneEmailMergeHandler handler;
 
+  static final String SURVIVING_PERSON_UID = "survivor123";
+  static final String PHONE_EMAIL_LOCATOR_1 = "locator1";
+  static final String PHONE_EMAIL_LOCATOR_2 = "locator2";
+  static final String MATCH_ID = "match-001";
+
   @BeforeEach
   void setUp() {
     handler = new PersonPhoneEmailMergeHandler(nbsTemplate);
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   void handleMerge_shouldPerformAllPersonPhoneEmailRelatedDatabaseOperations() {
-    String survivingId = "survivorId1";
-    String matchId = "match123";
-    PatientMergeRequest request = getPatientMergeRequest(survivingId);
+    // Prepare request and audit
+    PatientMergeRequest request = getPatientMergeRequest();
+    PatientMergeAudit audit = new PatientMergeAudit(new ArrayList<>());
 
-    handler.handleMerge(matchId, request);
+    // Mock DB queries
+    mockAuditForUnselectedPhoneEmails();
+    mockSelectedLocatorsForInsert();
 
-    verify(nbsTemplate).update(eq(PersonPhoneEmailMergeHandler.UPDATE_UN_SELECTED_PHONE_EMAIL_INACTIVE),
-        (Map<String, Object>) argThat(params -> {
-          Map<String, Object> paramMap = (Map<String, Object>) params;
-          return survivingId.equals(paramMap.get("survivingId")) &&
-              List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
-        }));
+    // Call the method under test
+    handler.handleMerge(MATCH_ID, request, audit);
 
-    verify(nbsTemplate).update(eq(PersonPhoneEmailMergeHandler.INSERT_NEW_PHONE_EMAIL_LOCATORS),
-        (Map<String, Object>) argThat(params -> {
-          Map<String, Object> paramMap = (Map<String, Object>) params;
-          return survivingId.equals(paramMap.get("survivingId")) &&
-              List.of("locator1", "locator2").equals(paramMap.get("selectedLocators"));
-        }));
+    // Verify DB operations
+    verifyInactiveUnselectedPhoneEmails();
+    verifySelectedPhoneEmailInsertions();
 
+    // Verify audit data
+    verifyAuditData(audit);
   }
 
-  private PatientMergeRequest getPatientMergeRequest(String survivingId) {
-    List<PatientMergeRequest.PhoneEmailId> phoneEmailIds = Arrays.asList(
-        new PatientMergeRequest.PhoneEmailId("locator1"),
-        new PatientMergeRequest.PhoneEmailId("locator2")
+  private PatientMergeRequest getPatientMergeRequest() {
+    List<PatientMergeRequest.PhoneEmailId> phoneEmailIds = List.of(
+        new PatientMergeRequest.PhoneEmailId(PHONE_EMAIL_LOCATOR_1),
+        new PatientMergeRequest.PhoneEmailId(PHONE_EMAIL_LOCATOR_2)
     );
-    return new PatientMergeRequest(survivingId, null,
-        null, null, phoneEmailIds, null, null, null,
-        null, null, null);
+
+    return new PatientMergeRequest(
+        PersonPhoneEmailMergeHandlerTest.SURVIVING_PERSON_UID, null, null, null,
+        phoneEmailIds, null, null, null, null, null, null
+    );
   }
 
+  @SuppressWarnings("unchecked")
+  private void mockAuditForUnselectedPhoneEmails() {
+    when(nbsTemplate.queryForList(
+        eq(PersonPhoneEmailMergeHandler.FIND_UNSELECTED_PHONE_EMAILS_FOR_AUDIT),
+        any(Map.class)
+    )).thenReturn(List.of(
+        Map.of(
+            "entity_uid", SURVIVING_PERSON_UID,
+            "locator_uid", "locator789",
+            "record_status_cd", "ACTIVE"
+        )
+    ));
+  }
 
+  @SuppressWarnings("unchecked")
+  private void mockSelectedLocatorsForInsert() {
+    when(nbsTemplate.queryForList(
+        eq(PersonPhoneEmailMergeHandler.FIND_SELECTED_PHONE_EMAIL_LOCATORS_FOR_INSERT),
+        any(Map.class)
+    )).thenReturn(List.of(
+        Map.of("locator_uid", PHONE_EMAIL_LOCATOR_1),
+        Map.of("locator_uid", PHONE_EMAIL_LOCATOR_2)
+    ));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void verifyInactiveUnselectedPhoneEmails() {
+    ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(nbsTemplate).update(
+        eq(PersonPhoneEmailMergeHandler.UPDATE_UN_SELECTED_PHONE_EMAIL_INACTIVE),
+        paramsCaptor.capture()
+    );
+
+    Map<String, Object> params = paramsCaptor.getValue();
+    assertEquals(SURVIVING_PERSON_UID, params.get("survivingId"));
+    assertTrue(((List<String>) params.get("selectedLocators"))
+        .containsAll(List.of(PHONE_EMAIL_LOCATOR_1, PHONE_EMAIL_LOCATOR_2)));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void verifySelectedPhoneEmailInsertions() {
+    ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(nbsTemplate).update(
+        eq(PersonPhoneEmailMergeHandler.INSERT_NEW_PHONE_EMAIL_LOCATORS),
+        paramsCaptor.capture()
+    );
+
+    Map<String, Object> params = paramsCaptor.getValue();
+    assertEquals(SURVIVING_PERSON_UID, params.get("survivingId"));
+    assertTrue(((List<String>) params.get("selectedLocators"))
+        .containsAll(List.of(PHONE_EMAIL_LOCATOR_1, PHONE_EMAIL_LOCATOR_2)));
+  }
+
+  private void verifyAuditData(PatientMergeAudit audit) {
+    assertEquals(1, audit.getRelatedTableAudits().size());
+
+    RelatedTableAudit tableAudit = audit.getRelatedTableAudits().getFirst();
+    assertEquals("Entity_locator_participation", tableAudit.tableName());
+
+    assertEquals(1, tableAudit.updates().size());
+    assertEquals(2, tableAudit.inserts().size());
+  }
 }

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandlerTest.java
@@ -1,6 +1,7 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
 import gov.cdc.nbs.deduplication.constants.QueryConstants;
+import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,9 @@ class PersonTableMergeHandlerTest {
 
   private PersonTableMergeHandler handler;
 
+  @Mock
+  private PatientMergeAudit patientMergeAudit;
+
   @BeforeEach
   void setUp() {
     handler = new PersonTableMergeHandler(nbsTemplate, deduplicationTemplate);
@@ -39,7 +43,7 @@ class PersonTableMergeHandlerTest {
     mockFetchSupersededCandidatesToReturn("superseded1", "superseded2", "superseded3");
     mockFetchChildIdsOfSupersededToReturn("supersededChild1", "supersededChild2", "supersededChild3");
 
-    handler.handleMerge(matchId, request);
+    handler.handleMerge(matchId, request, patientMergeAudit);
 
     verifyCopyPersonToHistory();
     verifyIncrementPersonVersionNumber();


### PR DESCRIPTION

When patients are merged, store detailed data from both the surviving and superseded records,
along with the merge options selected by the user. This prepares the system for a future
unmerge capability by tracking necessary audit and recovery data.

Each database operation during merge is captured as either:
- Insert: store the primary key of the new record to support future deletion.
- Update: store the primary key and the previous field values to enable restoring the original state before merge.


## JIRA

https://cdc-nbs.atlassian.net/browse/CND-358