### PR TITLE
Fix missing columns in person_merge during NBS 7 merge

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/constants/QueryConstants.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/constants/QueryConstants.java
@@ -482,24 +482,30 @@ public class QueryConstants {
       """;
 
   public static final String INSERT_PERSON_MERGE_RECORD = """
-       INSERT INTO PERSON_MERGE (
-          SURVIVING_PERSON_UID,
-          superced_person_uid,
-          surviving_parent_uid,
-          superceded_parent_uid,
-          MERGE_TIME,
-          superceded_version_ctrl_nbr,
-          RECORD_STATUS_CD
-      ) VALUES (
-          :survivorPersonId,
-          :supersededPersonId,
-          :survivorPersonId,
-          :supersededPersonId,
-          :mergeTime,
-          (SELECT MAX(version_ctrl_nbr) FROM person_hist where person_uid = :supersededPersonId),
-          'PAT_MERGE'
-      )
-      """;
+    INSERT INTO PERSON_MERGE (
+        SURVIVING_PERSON_UID,
+        superced_person_uid,
+        surviving_parent_uid,
+        superceded_parent_uid,
+        MERGE_TIME,
+        superceded_version_ctrl_nbr,
+        surviving_version_ctrl_nbr,
+        RECORD_STATUS_CD,
+        record_status_time,
+        merge_user_id
+    ) VALUES (
+        :survivorPersonId,
+        :supersededPersonId,
+        (SELECT person_parent_uid FROM person WHERE person_uid = :survivorPersonId),
+        (SELECT person_parent_uid FROM person WHERE person_uid = :supersededPersonId),
+        :mergeTime,
+        (SELECT MAX(version_ctrl_nbr) FROM person_hist WHERE person_uid = :supersededPersonId),
+        (SELECT MAX(version_ctrl_nbr) FROM person_hist WHERE person_uid = :survivorPersonId),
+        'PAT_MERGE',
+        :mergeTime,
+        :mergeUserId
+    )
+    """;
 
   public static final String CHILD_IDS_BY_PARENT_PERSON_IDS = """
       SELECT person_uid

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandler.java
@@ -5,11 +5,13 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
+import gov.cdc.nbs.deduplication.config.auth.user.NbsUserDetails;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.annotation.Order;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -119,13 +121,14 @@ public class PersonTableMergeHandler implements SectionMergeHandler {
   }
 
   private void saveSupersededPersonMergeDetails(String survivorPersonId, List<String> supersededPersonIds) {
-
+    NbsUserDetails currentUser = (NbsUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
     MapSqlParameterSource[] batchParameters = supersededPersonIds.stream()
         .map(supersededPersonId -> {
           MapSqlParameterSource parameters = new MapSqlParameterSource();
           parameters.addValue("survivorPersonId", survivorPersonId);
           parameters.addValue("supersededPersonId", supersededPersonId);
           parameters.addValue("mergeTime", Timestamp.from(Instant.now()));
+          parameters.addValue("mergeUserId", currentUser.getId());
           return parameters;
         })
         .toArray(MapSqlParameterSource[]::new);

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/handler/PersonTableMergeHandlerTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge.handler;
 
+import gov.cdc.nbs.deduplication.config.auth.user.NbsUserDetails;
 import gov.cdc.nbs.deduplication.constants.QueryConstants;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeAudit;
 import gov.cdc.nbs.deduplication.merge.model.PatientMergeRequest;
@@ -10,6 +11,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Arrays;
 
@@ -40,6 +44,7 @@ class PersonTableMergeHandlerTest {
     String matchId = "123";
     PatientMergeRequest request = getPatientMergeRequest();
 
+    mockSecurityContext();
     mockFetchSupersededCandidatesToReturn("superseded1", "superseded2", "superseded3");
     mockFetchChildIdsOfSupersededToReturn("supersededChild1", "supersededChild2", "supersededChild3");
 
@@ -65,6 +70,19 @@ class PersonTableMergeHandlerTest {
         eq(QueryConstants.CHILD_IDS_BY_PARENT_PERSON_IDS),
         any(MapSqlParameterSource.class),
         eq(String.class))).thenReturn(Arrays.asList(ids));
+  }
+
+  private void mockSecurityContext() {
+    NbsUserDetails mockUserDetails = mock(NbsUserDetails.class);
+    when(mockUserDetails.getId()).thenReturn(100L);
+
+    Authentication authentication = mock(Authentication.class);
+    when(authentication.getPrincipal()).thenReturn(mockUserDetails);
+
+    SecurityContext securityContext = mock(SecurityContext.class);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+
+    SecurityContextHolder.setContext(securityContext);
   }
 
   private void verifyCopyPersonToHistory() {


### PR DESCRIPTION
Fix missing columns in person_merge table during NBS 7 merge

Ensure all required columns are included in the person_merge table
when performing a merge operation in NBS 7 to maintain data integrity
and consistency

## JIRA

https://cdc-nbs.atlassian.net/browse/CND-384