### PR TITLE
Persist the Date and the user that performed the 'No merge' action

### DIFF
--- a/containers/db/initialize/restore.d/04-create-deduplication-db.sql
+++ b/containers/db/initialize/restore.d/04-create-deduplication-db.sql
@@ -32,10 +32,10 @@ CREATE TABLE nbs_mpi_mapping (
 );
 GO
 
+
 CREATE TABLE matches_requiring_review (
   id BIGINT IDENTITY(1,1) PRIMARY KEY,
   person_uid BIGINT NOT NULL,
-  person_local_id BIGINT NOT NULL,
   person_name NVARCHAR(300),
   person_add_time DATETIME NOT NULL,
   date_identified DATETIME DEFAULT GETDATE()
@@ -47,16 +47,8 @@ CREATE TABLE match_candidates (
   match_id BIGINT NOT NULL,
   person_uid BIGINT NOT NULL,
   is_merge BIT NULL,
+  last_chg_time DATETIME NULL,
+  last_chg_user_id BIGINT NULL,
   FOREIGN KEY (match_id) REFERENCES matches_requiring_review(id)
-);
-GO
-
-CREATE TABLE patient_merge_audit (
-    id BIGINT IDENTITY(1,1) PRIMARY KEY,
-    survivor_id VARCHAR(20) NOT NULL,
-    superseded_ids VARCHAR(200) NOT NULL,
-    merge_time DATETIME NOT NULL DEFAULT getdate(),
-    related_table_audits_json NVARCHAR(MAX) NOT NULL, -- Serialized PatientMergeAudit object
-	patient_merge_request_json NVARCHAR(MAX) NOT NULL -- Serialized PatientMergeRequest object
 );
 GO

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/constants/QueryConstants.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/constants/QueryConstants.java
@@ -450,10 +450,13 @@ public class QueryConstants {
 
   public static final String UN_MERGE_ALL_GROUP = """
           UPDATE mc
-          SET is_merge = 0
+          SET is_merge = 0,
+              last_chg_time = GETDATE(),
+              last_chg_user_id = :userId
           FROM match_candidates mc
           WHERE mc.match_id = :matchId
       """;
+
 
   public static final String SET_IS_MERGE_TO_FALSE_FOR_EXCLUDED_PATIENTS = """
           UPDATE mc
@@ -1016,11 +1019,13 @@ public class QueryConstants {
       """;
 
   public static final String UN_MERGE_SINGLE_PERSON = """
-      UPDATE mc
-      SET is_merge = 0
-      FROM match_candidates mc
-      WHERE mc.match_id = :matchId
-      AND mc.person_uid = :potentialMatchPersonUid
+          UPDATE mc
+          SET is_merge = 0,
+              last_chg_time = GETDATE(),
+              last_chg_user_id = :userId
+          FROM match_candidates mc
+          WHERE mc.match_id = :matchId
+            AND mc.person_uid = :potentialMatchPersonUid
       """;
 
   public static final String MPI_PATIENT_EXISTS_CHECK = """

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/MergeGroupHandler.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/MergeGroupHandler.java
@@ -3,9 +3,11 @@ package gov.cdc.nbs.deduplication.merge;
 import java.sql.ResultSet;
 import java.util.List;
 
+import gov.cdc.nbs.deduplication.config.auth.user.NbsUserDetails;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 import gov.cdc.nbs.deduplication.batch.model.PersonMergeData;
@@ -38,17 +40,28 @@ public class MergeGroupHandler {
         parameters, (ResultSet rs, int rowNum) -> rs.getString(1));
   }
 
-  public void removeAll(Long matchId) {// Keep Separate
+  public void removeAll(Long matchId) {
+    NbsUserDetails currentUser = (NbsUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
     MapSqlParameterSource parameters = new MapSqlParameterSource();
     parameters.addValue("matchId", matchId);
+    parameters.addValue("userId", currentUser.getId());
+
     deduplicationTemplate.update(QueryConstants.UN_MERGE_ALL_GROUP, parameters);
   }
 
+
   public void removePerson(Long matchId, Long potentialMatchPersonUid) {
+    NbsUserDetails currentUser = (NbsUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
     MapSqlParameterSource parameters = new MapSqlParameterSource();
     parameters.addValue("matchId", matchId);
     parameters.addValue("potentialMatchPersonUid", potentialMatchPersonUid);
+    parameters.addValue("userId", currentUser.getId());
+
     deduplicationTemplate.update(QueryConstants.UN_MERGE_SINGLE_PERSON, parameters);
   }
+
+
 
 }


### PR DESCRIPTION

The Date and time as well as the user that performed the action should be set when the “No merge” action is taken.

## JIRA
https://cdc-nbs.atlassian.net/browse/CND-383