### PR TITLE
Make include_multiple_matches configurable

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/pass/AlgorithmMapper.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/pass/AlgorithmMapper.java
@@ -22,9 +22,11 @@ import gov.cdc.nbs.deduplication.algorithm.pass.model.ui.Algorithm.Pass;
 
 public class AlgorithmMapper {
   private final String algorithmName;
+  private final boolean includeMultipleMatches;
 
-  public AlgorithmMapper(String algorithmName) {
+  public AlgorithmMapper(String algorithmName, boolean includeMultipleMatches) {
     this.algorithmName = algorithmName;
+    this.includeMultipleMatches = includeMultipleMatches;
   }
 
   // Converts NBS Algorithm to DIBBs algorithm format
@@ -51,7 +53,7 @@ public class AlgorithmMapper {
         .toList();
 
     return new AlgorithmContext(
-        true,
+        includeMultipleMatches,
         logOdds,
         new Advanced(
             SimilarityMeasure.JAROWINKLER,

--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/pass/PassService.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/algorithm/pass/PassService.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -27,7 +28,11 @@ public class PassService {
   private final DataElementsService dataElementsService;
   private final DibbsService dibbsService;
   private final ObjectMapper mapper;
-  private final AlgorithmMapper algorithmMapper = new AlgorithmMapper("nbs");
+
+  @Value("${deduplication.algorithm.allowMultipleMatches:false}")
+  private boolean allowMultipleMatches;
+
+  private final AlgorithmMapper algorithmMapper = new AlgorithmMapper("nbs",allowMultipleMatches);
 
   public PassService(
       @Qualifier("deduplicationNamedTemplate") final NamedParameterJdbcTemplate template,

--- a/deduplication/src/main/resources/application.yaml
+++ b/deduplication/src/main/resources/application.yaml
@@ -66,6 +66,7 @@ deduplication:
   algorithm:
     # should data elements and algorithm updates be pushed to Record Linker API
     updateRecordLinker: ${ALGORITHM_UPDATE_RL:false}
+    allowMultipleMatches: false
   sync:
     enabled: ${SYNC_ENABLED:false}
   batch:

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/pass/AlgorithmMapperTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/pass/AlgorithmMapperTest.java
@@ -27,7 +27,7 @@ import gov.cdc.nbs.deduplication.algorithm.pass.model.ui.Algorithm.Pass;
 
 class AlgorithmMapperTest {
 
-  private final AlgorithmMapper mapper = new AlgorithmMapper("nbs");
+  private final AlgorithmMapper mapper = new AlgorithmMapper("nbs",false);
 
   @Test
   void should_set_name() {
@@ -50,7 +50,7 @@ class AlgorithmMapperTest {
   @Test
   void should_set_multiple_matches() {
     DibbsAlgorithm actual = mapper.map(new Algorithm(new ArrayList<>()), TestData.DATA_ELEMENTS);
-    assertThat(actual.algorithmContext().includeMultipleMatches()).isTrue();
+    assertThat(actual.algorithmContext().includeMultipleMatches()).isFalse();
   }
 
   @Test

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/pass/PassServiceTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/algorithm/pass/PassServiceTest.java
@@ -56,19 +56,19 @@ class PassServiceTest {
     @InjectMocks
     private PassService service;
 
-    private AlgorithmMapper algorithmMapper = new AlgorithmMapper("nbs");
+    private AlgorithmMapper algorithmMapper = new AlgorithmMapper("nbs",false);
 
     private final Pass pass = new Pass(
-            1l,
-            "pass 1",
-            "description 1",
-            true,
-            List.of(BlockingAttribute.ADDRESS),
-            List.of(
-                    new MatchingAttributeEntry(MatchingAttribute.FIRST_NAME, MatchingMethod.EXACT, 0.7),
-                    new MatchingAttributeEntry(MatchingAttribute.LAST_NAME, MatchingMethod.JAROWINKLER, 0.8)),
-            0.52,
-            0.92);
+        1l,
+        "pass 1",
+        "description 1",
+        true,
+        List.of(BlockingAttribute.ADDRESS),
+        List.of(
+            new MatchingAttributeEntry(MatchingAttribute.FIRST_NAME, MatchingMethod.EXACT, 0.7),
+            new MatchingAttributeEntry(MatchingAttribute.LAST_NAME, MatchingMethod.JAROWINKLER, 0.8)),
+        0.52,
+        0.92);
 
     private final Algorithm algorithm = new Algorithm(Stream.of(pass).collect(Collectors.toCollection(ArrayList::new)));
 
@@ -77,9 +77,9 @@ class PassServiceTest {
         when(template.getJdbcTemplate()).thenReturn(mockTemplate);
 
         when(mockTemplate.queryForList(
-                PassService.SELECT_CURRENT_CONFIG,
-                String.class))
-                .thenReturn(List.of("response"));
+            PassService.SELECT_CURRENT_CONFIG,
+            String.class))
+            .thenReturn(List.of("response"));
 
         when(mapper.readValue("response", Algorithm.class)).thenReturn(returnedAlgorithm);
     }
@@ -99,9 +99,9 @@ class PassServiceTest {
         when(template.getJdbcTemplate()).thenReturn(mockTemplate);
 
         when(mockTemplate.queryForList(
-                PassService.SELECT_CURRENT_CONFIG,
-                String.class))
-                .thenReturn(List.of());
+            PassService.SELECT_CURRENT_CONFIG,
+            String.class))
+            .thenReturn(List.of());
 
         Algorithm actual = service.getCurrentAlgorithm();
 
@@ -114,9 +114,9 @@ class PassServiceTest {
         when(template.getJdbcTemplate()).thenReturn(mockTemplate);
 
         when(mockTemplate.queryForList(
-                PassService.SELECT_CURRENT_CONFIG,
-                String.class))
-                .thenReturn(List.of("response"));
+            PassService.SELECT_CURRENT_CONFIG,
+            String.class))
+            .thenReturn(List.of("response"));
 
         when(mapper.readValue("response", Algorithm.class)).thenThrow(JsonProcessingException.class);
 
@@ -136,16 +136,16 @@ class PassServiceTest {
         when(template.update(eq(PassService.INSERT_CONFIG), captor.capture())).thenReturn(1);
 
         Algorithm actual = service.save(new Pass(
-                null,
-                "pass 2",
-                "description 2",
-                true,
-                List.of(BlockingAttribute.SEX),
-                List.of(
-                        new MatchingAttributeEntry(MatchingAttribute.ADDRESS, MatchingMethod.EXACT, 0.77),
-                        new MatchingAttributeEntry(MatchingAttribute.BIRTHDATE, MatchingMethod.EXACT, 0.9)),
-                0.52,
-                0.92));
+            null,
+            "pass 2",
+            "description 2",
+            true,
+            List.of(BlockingAttribute.SEX),
+            List.of(
+                new MatchingAttributeEntry(MatchingAttribute.ADDRESS, MatchingMethod.EXACT, 0.77),
+                new MatchingAttributeEntry(MatchingAttribute.BIRTHDATE, MatchingMethod.EXACT, 0.9)),
+            0.52,
+            0.92));
 
         assertThat(actual).isEqualTo(algorithm);
         verify(dibbsService, times(1)).save(algorithmMapper.map(actual, TestData.DATA_ELEMENTS));
@@ -203,16 +203,16 @@ class PassServiceTest {
         when(template.update(eq(PassService.INSERT_CONFIG), captor.capture())).thenReturn(1);
 
         Pass updatedPass = new Pass(
-                4l,
-                "updated name",
-                "updated description",
-                false,
-                List.of(BlockingAttribute.BIRTHDATE),
-                List.of(
-                        new MatchingAttributeEntry(MatchingAttribute.ADDRESS, MatchingMethod.EXACT, 0.8),
-                        new MatchingAttributeEntry(MatchingAttribute.PHONE, MatchingMethod.EXACT, 1.0)),
-                0.52,
-                0.92);
+            4l,
+            "updated name",
+            "updated description",
+            false,
+            List.of(BlockingAttribute.BIRTHDATE),
+            List.of(
+                new MatchingAttributeEntry(MatchingAttribute.ADDRESS, MatchingMethod.EXACT, 0.8),
+                new MatchingAttributeEntry(MatchingAttribute.PHONE, MatchingMethod.EXACT, 1.0)),
+            0.52,
+            0.92);
         Algorithm actual = service.update(1l, updatedPass);
 
         verify(dibbsService, times(1)).save(algorithmMapper.map(actual, TestData.DATA_ELEMENTS));
@@ -226,8 +226,8 @@ class PassServiceTest {
         mockCurrentConfig(algorithm);
 
         PassModificationException ex = assertThrows(
-                PassModificationException.class,
-                () -> service.update(2l, null));
+            PassModificationException.class,
+            () -> service.update(2l, null));
         assertThat(ex.getMessage()).isEqualTo("Failed to find pass with Id: 2");
     }
 
@@ -252,29 +252,29 @@ class PassServiceTest {
     void delete_pass_two_passes() throws JsonProcessingException {
         List<Pass> passes = new ArrayList<>();
         passes.add(
-                new Pass(
-                        1l,
-                        "pass 1",
-                        "description 1",
-                        true,
-                        List.of(BlockingAttribute.ADDRESS),
-                        List.of(
-                                new MatchingAttributeEntry(MatchingAttribute.FIRST_NAME, MatchingMethod.EXACT, 0.45),
-                                new MatchingAttributeEntry(MatchingAttribute.LAST_NAME, MatchingMethod.JAROWINKLER,
-                                        0.32)),
-                        0.52,
-                        0.92));
+            new Pass(
+                1l,
+                "pass 1",
+                "description 1",
+                true,
+                List.of(BlockingAttribute.ADDRESS),
+                List.of(
+                    new MatchingAttributeEntry(MatchingAttribute.FIRST_NAME, MatchingMethod.EXACT, 0.45),
+                    new MatchingAttributeEntry(MatchingAttribute.LAST_NAME, MatchingMethod.JAROWINKLER,
+                        0.32)),
+                0.52,
+                0.92));
         passes.add(
-                new Pass(
-                        2l,
-                        "pass 2",
-                        "description 2",
-                        true,
-                        List.of(BlockingAttribute.BIRTHDATE),
-                        List.of(
-                                new MatchingAttributeEntry(MatchingAttribute.ADDRESS, MatchingMethod.EXACT, 0.88)),
-                        0.52,
-                        0.92));
+            new Pass(
+                2l,
+                "pass 2",
+                "description 2",
+                true,
+                List.of(BlockingAttribute.BIRTHDATE),
+                List.of(
+                    new MatchingAttributeEntry(MatchingAttribute.ADDRESS, MatchingMethod.EXACT, 0.88)),
+                0.52,
+                0.92));
         Algorithm algorithmWithTwoPasses = new Algorithm(passes);
         mockCurrentConfig(algorithmWithTwoPasses);
 
@@ -298,8 +298,8 @@ class PassServiceTest {
         mockCurrentConfig(algorithm);
 
         PassModificationException ex = assertThrows(
-                PassModificationException.class,
-                () -> service.delete(2l));
+            PassModificationException.class,
+            () -> service.delete(2l));
         assertThat(ex.getMessage()).isEqualTo("Failed to find pass with Id: 2");
     }
 
@@ -311,9 +311,9 @@ class PassServiceTest {
         service.saveDibbsAlgorithm();
 
         verify(
-                dibbsService,
-                times(1))
-                .save(algorithmMapper.map(algorithm, TestData.DATA_ELEMENTS));
+            dibbsService,
+            times(1))
+            .save(algorithmMapper.map(algorithm, TestData.DATA_ELEMENTS));
     }
 
     @Test


### PR DESCRIPTION

- Added deduplication.algorithm.allowMultipleMatches property with default false
- Replaced hardcoded true with configurable value in AlgorithmContext


## JIRA
https://cdc-nbs.atlassian.net/browse/CND-409