### PR TITLE
Move GET above DELETE

### DIFF
--- a/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/PatientMergeController.java
+++ b/deduplication/src/main/java/gov/cdc/nbs/deduplication/merge/PatientMergeController.java
@@ -60,6 +60,13 @@ public class PatientMergeController {
     return mergeGroupService.getMergeGroup(groupId);
   }
 
+  @GetMapping("/status/{personUid}")
+  public PatientMergeQueueStatus getMergeQueueStatus(@PathVariable("personUid") String personUid) {
+    Long mergeGroup = matchesRequiringReviewResolver.findLatestMergeGroupForPatient(personUid);
+    boolean inQueue = mergeGroup != null;
+    return new PatientMergeQueueStatus(inQueue, mergeGroup);
+  }
+
   @DeleteMapping("/{groupId}/{personUid}")
   public void markNoMerge(
       @PathVariable("groupId") Long groupId,
@@ -78,13 +85,6 @@ public class PatientMergeController {
       @RequestBody PatientMergeRequest mergeRequest,
       @PathVariable("groupId") Long groupId) throws JsonProcessingException {
     mergeService.performMerge(groupId, mergeRequest);
-  }
-
-  @GetMapping("/status/{personUid}")
-  public PatientMergeQueueStatus getMergeQueueStatus(@PathVariable("personUid") String personUid) {
-    Long mergeGroup = matchesRequiringReviewResolver.findLatestMergeGroupForPatient(personUid);
-    boolean inQueue = mergeGroup != null;
-    return new PatientMergeQueueStatus(inQueue, mergeGroup);
   }
 
   @GetMapping(value = "/export/csv", produces = "text/csv")


### PR DESCRIPTION
## Notes

Testing a bug fix in int1. The API was failing in int1 with 405 method not allowed error. The response contained allow: DELETE. Moving the @GetMapping code above delete to see if it fixes the issue.

## JIRA
NA

## Checklist

- [ ] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?