### PR TITLE
Fix merge_group_entries last_chg_user_id and last_chg_time not updating

### DIFF
--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/MergeServiceTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/merge/MergeServiceTest.java
@@ -1,5 +1,6 @@
 package gov.cdc.nbs.deduplication.merge;
 
+import gov.cdc.nbs.deduplication.SecurityTestUtil;
 import gov.cdc.nbs.deduplication.merge.handler.AdminCommentMergeHandler;
 import gov.cdc.nbs.deduplication.merge.handler.PersonTableMergeHandler;
 import gov.cdc.nbs.deduplication.merge.handler.SectionMergeHandler;
@@ -46,6 +47,7 @@ class MergeServiceTest {
 
     when(deduplicationClient.sql(MergeService.MARK_PATIENTS_AS_MERGED)).thenReturn(mockStatementSpec);
     when(mockStatementSpec.param("mergeGroup", 123L)).thenReturn(mockStatementSpec);
+    when(mockStatementSpec.param("userId", 220L)).thenReturn(mockStatementSpec);
     when(mockStatementSpec.update()).thenReturn(1); // simulate update success
 
     StatementSpec auditStatementSpec = Mockito.mock(StatementSpec.class);
@@ -70,6 +72,8 @@ class MergeServiceTest {
 
     // Mock objectMapper serialization
     when(objectMapper.writeValueAsString(any())).thenReturn(relatedAuditsJson, mergeRequestJson);
+
+    SecurityTestUtil.mockSecurityContext(220L);
 
     // Act
     mergeService.performMerge(matchId, request);

--- a/deduplication/src/test/java/gov/cdc/nbs/deduplication/sync/service/PersonDeleteSyncHandlerTest.java
+++ b/deduplication/src/test/java/gov/cdc/nbs/deduplication/sync/service/PersonDeleteSyncHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
+import gov.cdc.nbs.deduplication.SecurityTestUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -122,12 +123,15 @@ class PersonDeleteSyncHandlerTest {
   }
 
   private void mockCleanPotentialMerges(String id) {
+    SecurityTestUtil.mockSecurityContext(220L);
     StatementSpec spec = Mockito.mock(StatementSpec.class);
     when(deduplicationClient.sql(PersonDeleteSyncHandler.REMOVE_FROM_POTENTIAL_MERGES)).thenReturn(spec);
     when(spec.param("id", id)).thenReturn(spec);
+    when(spec.param("userId", 220L)).thenReturn(spec);
 
     StatementSpec spec2 = Mockito.mock(StatementSpec.class);
     when(deduplicationClient.sql(PersonDeleteSyncHandler.CLEAN_UP_POTENTIAL_MERGES)).thenReturn(spec2);
+    when(spec2.param("userId", 220L)).thenReturn(spec2);
   }
 
   private JsonNode createPayloadNode(String personUid, String personParentUid) {


### PR DESCRIPTION
Fix: Update last_chg_user_id and last_chg_time on merge_group_entries during updates
- Ensured last_chg_user_id and last_chg_time are properly updated when a patient is merged

## JIRA

https://cdc-nbs.atlassian.net/browse/CND-418