### PR TITLE
Remove database parameters as they are no longer used in sonar.yaml

### DIFF
--- a/.github/workflows/Build-and-deploy-data-ingestion.yaml
+++ b/.github/workflows/Build-and-deploy-data-ingestion.yaml
@@ -19,8 +19,6 @@ jobs:
       CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
       PASSED_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
-      DATABASE_USER: ${{secrets.DATABASE_USER}}
-      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD}}
   extract-version-suffix:
     needs: sonar_scan
     name: Extract image tag from version

--- a/.github/workflows/Build-and-deploy-data-processing.yaml
+++ b/.github/workflows/Build-and-deploy-data-processing.yaml
@@ -18,8 +18,6 @@ jobs:
       CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
       PASSED_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
-      DATABASE_USER: ${{secrets.DATABASE_USER}}
-      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD}}
   extract-version-suffix:
     name: Extract image tag from version
     needs: sonar_scan

--- a/.github/workflows/Build-and-deploy-deduplication-api.yaml
+++ b/.github/workflows/Build-and-deploy-deduplication-api.yaml
@@ -18,8 +18,6 @@ jobs:
       CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID: ${{secrets.CDC_NBS_SANDBOX_SHARED_SERVICES_ACCOUNTID}}
       PASSED_GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
-      DATABASE_USER: ${{secrets.DATABASE_USER}}
-      DATABASE_PASSWORD: ${{secrets.DATABASE_PASSWORD}}
  extract-version-suffix:
    name: Extract image tag from version
    needs: sonar_scan


### PR DESCRIPTION
## Notes

Fixes the image build workflows to remove the `DATABASE_USER` and `DATABASE_PASSWORD` parameters as they are no longer used in the `sonar.yaml` workflow.

The error was detected in the latest merge to main
https://github.com/CDCgov/NEDSS-DataIngestion/actions/runs/28249838173
```
[Invalid workflow file: .github/workflows/Build-and-deploy-deduplication-api.yaml#L21](https://github.com/CDCgov/NEDSS-DataIngestion/actions/runs/28249838173/workflow)
The workflow is not valid. .github/workflows/Build-and-deploy-deduplication-api.yaml (Line: 21, Col: 22): Invalid secret, DATABASE_USER is not defined in the referenced workflow. .github/workflows/Build-and-deploy-deduplication-api.yaml (Line: 22, Col: 26): Invalid secret, DATABASE_PASSWORD is not defined in the referenced workflow.
```