### PR TITLE
removes the pinned tomcat version

### DIFF
--- a/data-ingestion-service/build.gradle
+++ b/data-ingestion-service/build.gradle
@@ -278,14 +278,6 @@ dependencies {
   implementation files('libs/cda-schema.jar')
 }
 
-dependencyManagement {
-	dependencies {
-		dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.11'
-		dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.11'
-		dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.11'
-	}
-}
-
 test {
 	useJUnitPlatform()
 	finalizedBy jacocoTestReport

--- a/data-processing-service/build.gradle
+++ b/data-processing-service/build.gradle
@@ -212,16 +212,6 @@ dependencies {
     testImplementation(platform('org.junit:junit-bom:6.0.3'))
 }
 
-dependencyManagement {
-    dependencies {
-        dependency 'org.apache.tomcat.embed:tomcat-embed-core:11.0.11'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-el:11.0.11'
-        dependency 'org.apache.tomcat.embed:tomcat-embed-websocket:11.0.11'
-
-    }
-}
-
-
 test {
     finalizedBy jacocoTestReport // report is always generated after tests run
     jacoco {


### PR DESCRIPTION
## Notes

Attempts to resolve the tomcat vulnerabilities by removing the pinned version.

Scan shows 10.1.50 as fixed version
https://github.com/CDCgov/NEDSS-DataIngestion/security/code-scanning/281

Running
```sh
./gradlew data-ingestion-service:dependencies
./gradlew data-processing-service:dependencies
```

both now report:
```
+--- org.springframework.boot:spring-boot-starter-web -> 3.5.15
|    +--- org.springframework.boot:spring-boot-starter-tomcat:3.5.15
|    |    +--- org.apache.tomcat.embed:tomcat-embed-core:10.1.55
|    |    +--- org.apache.tomcat.embed:tomcat-embed-el:10.1.55
|    |    \--- org.apache.tomcat.embed:tomcat-embed-websocket:10.1.55
|    |         \--- org.apache.tomcat.embed:tomcat-embed-core:10.1.55
```

