### PR TITLE
Bump Spring Boot to 3.5.16

### DIFF
--- a/data-ingestion-service/build.gradle
+++ b/data-ingestion-service/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.15'
+	id 'org.springframework.boot' version '3.5.16'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'com.github.johnrengelman.shadow' version '7.1.2'
 	id 'jacoco'
@@ -245,9 +245,6 @@ dependencies {
   implementation 'com.google.code.gson:gson:2.13.2'
   implementation 'com.zaxxer:HikariCP:7.0.2'
   implementation 'org.apache.xmlbeans:xmlbeans:3.1.0'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.1'
-  implementation 'com.fasterxml.jackson.core:jackson-core:2.21.1'
-  implementation 'com.fasterxml.jackson.core:jackson-annotations:2.21'
   implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
   implementation 'org.hibernate.validator:hibernate-validator:9.1.0.Final'
   runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:4.0.2'

--- a/data-processing-service/build.gradle
+++ b/data-processing-service/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.15'
+    id 'org.springframework.boot' version '3.5.16'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'jacoco'
@@ -197,7 +197,7 @@ dependencies {
     // Misc
     implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'com.zaxxer:HikariCP:7.0.2'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.1'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.21.4'
     implementation 'org.hibernate.validator:hibernate-validator'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
     implementation 'org.apache.commons:commons-lang3:3.14.0'


### PR DESCRIPTION
## Notes

Bumps Spring Boot to `3.5.16` which pulls in `jackson-databind` and `jackson-core` of `2.21.4`. This should address some of the High and Medium vulnerabilities.

`/gradlew data-ingestion-service:dependencies`
```
+--- org.springframework.boot:spring-boot-starter-web -> 3.5.16
|    +--- org.springframework.boot:spring-boot-starter:3.5.16 (*)
|    +--- org.springframework.boot:spring-boot-starter-json:3.5.16
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.21.4
|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.21
|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.21.4
|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.21.4
|    |    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.21 (c)
|    |    |    |         +--- com.fasterxml.jackson.core:jackson-core:2.21.4 (c)
|    |    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.21.4 (c)
|    |    |    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.21.4 (c)
|    |    |    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.4 (c)
```

`./gradlew data-processing-service:dependencies`
```
+--- org.springframework.boot:spring-boot-starter-web -> 3.5.16
|    +--- org.springframework.boot:spring-boot-starter:3.5.16 (*)
|    +--- org.springframework.boot:spring-boot-starter-json:3.5.16
|    |    +--- com.fasterxml.jackson.core:jackson-databind:2.21.4
|    |    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.21
|    |    |    +--- com.fasterxml.jackson.core:jackson-core:2.21.4
|    |    |    |    \--- com.fasterxml.jackson:jackson-bom:2.21.4
|    |    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.21 (c)
|    |    |    |         +--- com.fasterxml.jackson.core:jackson-core:2.21.4 (c)
|    |    |    |         +--- com.fasterxml.jackson.core:jackson-databind:2.21.4 (c)
|    |    |    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.21.4 (c)
|    |    |    |         +--- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.4 (c)
```

## Vulnerability
https://github.com/CDCgov/NEDSS-DataIngestion/security/code-scanning/253
https://github.com/CDCgov/NEDSS-DataIngestion/security/code-scanning/252
https://github.com/CDCgov/NEDSS-DataIngestion/security/code-scanning/258
https://github.com/CDCgov/NEDSS-DataIngestion/security/code-scanning/257
https://github.com/CDCgov/NEDSS-DataIngestion/security/code-scanning/256
https://github.com/CDCgov/NEDSS-DataIngestion/security/code-scanning/254

These probably wont get fixed as the CVE says 2.21.5 is the "fixed" version, but 2.21.5 is not yet released
https://github.com/CDCgov/NEDSS-DataIngestion/security/code-scanning/255 
https://github.com/CDCgov/NEDSS-DataIngestion/security/code-scanning/279 
https://github.com/CDCgov/NEDSS-DataIngestion/security/code-scanning/277 

Release schedule:
Source: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.21
