### PR TITLE
APP-800: Pin deduplication mssql-jdbc to 13.4.0.jre11 (CVE-2025-59250)

### DIFF
--- a/deduplication/build.gradle
+++ b/deduplication/build.gradle
@@ -42,7 +42,9 @@ dependencies {
 
   // database
   implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-  runtimeOnly 'com.microsoft.sqlserver:mssql-jdbc'
+  // APP-800: pin to match data-ingestion/data-processing services and clear CVE-2025-59250
+  // (Spring BOM's managed 12.10.2.jre11 trips Trivy's .jre-suffix comparison).
+  runtimeOnly 'com.microsoft.sqlserver:mssql-jdbc:13.4.0.jre11'
   runtimeOnly 'org.postgresql:postgresql'
 
   // swagger


### PR DESCRIPTION
## APP-800: patch the actionable high vuln in the DI deduplication service

Addresses the one Gradle-fixable critical/high Trivy finding in the DataIngestion repo for [APP-800](https://cdc-nbs.atlassian.net/browse/APP-800).

### Change
`deduplication` pulled `mssql-jdbc` with no explicit version, so it inherited the Spring dependency-management BOM's `12.10.2.jre11`. Trivy flags that for **CVE-2025-59250** because of how it handles the `.jre11` suffix: it reads the installed version as `12.10.2` and sees it as below the `12.10.2.jre11` fix. The `data-ingestion-service` and `data-processing-service` already pin `13.4.0.jre11`, which Trivy treats as clean since it sits well above the fix boundary.

Pinning `deduplication` to `13.4.0.jre11` clears the finding and aligns the driver version across all three DI services.

### Verification
- `deduplication` resolves `mssql-jdbc:13.4.0.jre11` on the runtime classpath.
- `deduplication`: 274/274 tests pass.

### Out of scope (blocked on upstream)
The two remaining highs are OS packages in the `nbs7-deduplication-api` container's `redhat/ubi9-micro` base image rather than Java dependencies:
- CVE-2026-54371 (`libattr` 2.5.1-3.el9)
- CVE-2026-54369 (`libacl` 2.3.1-4.el9)

Both report an empty Fixed Version, so Red Hat hasn't shipped patched RPMs for UBI9 yet and no base-image bump resolves them today. These are flagged for DevOps to monitor. The remaining DI mediums (jackson-databind 2.21.4, commons-lang3) fall outside this ticket's critical/high scope.


[APP-800]: https://cdc-nbs.atlassian.net/browse/APP-800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ