### PR TITLE
(fix) Install findutils in Dockerfile to fix deploy workflow

### DIFF
--- a/data-ingestion-service/Dockerfile
+++ b/data-ingestion-service/Dockerfile
@@ -2,6 +2,8 @@ FROM amazoncorretto:21 as builder
 
 # try patching system for security fixes
 RUN yum update -y && yum clean all
+
+# Install xargs, used by a few deps in the gradle build process
 RUN yum install -y findutils
 
 #Copy project config

--- a/data-ingestion-service/Dockerfile
+++ b/data-ingestion-service/Dockerfile
@@ -2,6 +2,7 @@ FROM amazoncorretto:21 as builder
 
 # try patching system for security fixes
 RUN yum update -y && yum clean all
+RUN yum install -y findutils
 
 #Copy project config
 COPY gradle /usr/src/dataingestion/gradle

--- a/data-ingestion-service/Dockerfile
+++ b/data-ingestion-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21 as builder
+FROM amazoncorretto:21 AS builder
 
 # try patching system for security fixes
 RUN yum update -y && yum clean all


### PR DESCRIPTION
## Notes

Looks like the recent netty update introduced an expectation of `xargs` as part of it's build process in maven, causing [the deploy workflow to fail](https://github.com/CDCgov/NEDSS-DataIngestion/actions/runs/31746124344/job/94602873620).  This PR addresses that by explicitly installing `findutils` in our `Dockerfile` (the package containing `xargs`), which [looks to have things running again](https://github.com/CDCgov/NEDSS-DataIngestion/actions/runs/31770096167).

## JIRA

N/A

## Checklist

- [ ] PR focuses on a single story.
- [ ] New unit tests added and ensured they pass.
- [ ] Service has been tested in local and it works as expected.
- [ ] Documentation has been updated for this code change (if needed).
- [ ] Code follows the Java Coding Conventions (https://www.oracle.com/java/technologies/javase/codeconventions-programmingpractices.html).

## Types of changes

What types of changes does this PR introduces?

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change

## Testing

- [ ] Does this PR has >90% code coverage?
- [ ] Is the screenshot attached for code coverage?
- [ ] Does the `gradle build` pass in your local? 
- [ ] Is the `gradle build` logs attached?