### PR TITLE
build: update org.apache.httpcomponents.core5:httpcore5 to fix vuln

### DIFF
--- a/data-ingestion-service/build.gradle
+++ b/data-ingestion-service/build.gradle
@@ -238,6 +238,9 @@ dependencies {
   implementation 'io.netty:netty-codec-http:4.1.136.Final'
   implementation 'io.netty:netty-codec-http2:4.1.136.Final'
 
+  // Transitive Apache httpcomponents dependency, needed to fix CVE-2026-54399
+  implementation 'org.apache.httpcomponents.core5:httpcore5:5.4.3'
+
   // Lombok annotations
   compileOnly 'org.projectlombok:lombok:1.18.34'
   annotationProcessor 'org.projectlombok:lombok:1.18.34'


### PR DESCRIPTION
## Notes

Squash High vuln related to `org.apache.httpcomponents.core5:httpcore5`.